### PR TITLE
PD-9426 Integration Tests for Associations

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiIntegrationTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Execution;
-using HubSpot.NET.Api.Company.Dto;
 using HubSpot.NET.Api.Contact.Dto;
 
 namespace HubSpot.NET.IntegrationTests.Api.Associations;
@@ -21,20 +20,43 @@ public sealed class HubSpotAssociationsApiIntegrationTests : HubSpotIntegrationT
         AssociationsApi.AssociationToObject(expectedObjectType, expectedObjectId, expectedToObjectType,
             expectedToObjectId);
 
-        // Need to wait for data to be searchable. Adjust delay based on your requirements/observations.
+        // Need to wait for data to be searchable.
         await Task.Delay(7000);
 
-        var fetchedCompany = CompanyApi.GetById<CompanyHubSpotModel>(expectedCompany.Id.Value);
         var fetchedContact = ContactApi.GetById<ContactHubSpotModel>(expectedContact.Id.Value);
 
         using (new AssertionScope())
         {
             fetchedContact.AssociatedCompanyId.Should().Be(expectedCompany.Id.Value,
                 "The associated company ID should be present in the retrieved contact");
+        }
+    }
 
-            fetchedCompany.Associations.Should().NotBeNull("Expected to retrieve associations set for the company.");
-            fetchedCompany.Associations.AssociatedContacts.Should().Contain(expectedContact.Id.Value,
-                "The associated contact ID should be present in the retrieved associations.");
+    [Fact(Skip = "Depends on the implementation of label API handling")]
+    public async Task CreateAssociationByLabelAndFetchToObject()
+    {
+        var expectedCompany = CreateTestCompany();
+        var expectedContact = RecreateTestContact();
+
+        var expectedObjectType = "Company";
+        var expectedObjectId = expectedCompany.Id.Value.ToString();
+        var expectedToObjectType = "Contact";
+        var expectedToObjectId = expectedContact.Id.Value.ToString();
+        var expectedAssociationCategory = "YOUR_ASSOCIATION_CATEGORY";
+        var expectedAssociationTypeId = 0; // replace with your actual association type ID
+
+        AssociationsApi.AssociationToObjectByLabel(expectedObjectType, expectedObjectId, expectedToObjectType,
+            expectedToObjectId, expectedAssociationCategory, expectedAssociationTypeId);
+
+        // Need to wait for data to be searchable.
+        await Task.Delay(7000);
+
+        var fetchedContact = ContactApi.GetById<ContactHubSpotModel>(expectedContact.Id.Value);
+
+        using (new AssertionScope())
+        {
+            fetchedContact.AssociatedCompanyId.Should().Be(expectedCompany.Id.Value,
+                "The associated company ID should be present in the retrieved contact");
         }
     }
 }

--- a/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiIntegrationTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using HubSpot.NET.Api.Company.Dto;
+using HubSpot.NET.Api.Contact.Dto;
+
+namespace HubSpot.NET.IntegrationTests.Api.Associations;
+
+public sealed class HubSpotAssociationsApiIntegrationTests : HubSpotIntegrationTestBase
+{
+    [Fact]
+    public async Task CreateAssociationAndFetchToObject()
+    {
+        var expectedCompany = CreateTestCompany();
+        var expectedContact = RecreateTestContact();
+
+        var expectedObjectType = "Company";
+        var expectedObjectId = expectedCompany.Id.Value.ToString();
+        var expectedToObjectType = "Contact";
+        var expectedToObjectId = expectedContact.Id.Value.ToString();
+
+        AssociationsApi.AssociationToObject(expectedObjectType, expectedObjectId, expectedToObjectType,
+            expectedToObjectId);
+
+        // Need to wait for data to be searchable. Adjust delay based on your requirements/observations.
+        await Task.Delay(7000);
+
+        var fetchedCompany = CompanyApi.GetById<CompanyHubSpotModel>(expectedCompany.Id.Value);
+        var fetchedContact = ContactApi.GetById<ContactHubSpotModel>(expectedContact.Id.Value);
+
+        using (new AssertionScope())
+        {
+            fetchedContact.AssociatedCompanyId.Should().Be(expectedCompany.Id.Value,
+                "The associated company ID should be present in the retrieved contact");
+
+            fetchedCompany.Associations.Should().NotBeNull("Expected to retrieve associations set for the company.");
+            fetchedCompany.Associations.AssociatedContacts.Should().Contain(expectedContact.Id.Value,
+                "The associated contact ID should be present in the retrieved associations.");
+        }
+    }
+}

--- a/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiIntegrationTests.cs
@@ -9,7 +9,7 @@ public sealed class HubSpotAssociationsApiIntegrationTests : HubSpotIntegrationT
     [Fact]
     public async Task CreateAssociationAndFetchToObject()
     {
-        var expectedCompany = CreateTestCompany();
+        var expectedCompany = RecreateTestCompany();
         var expectedContact = RecreateTestContact();
 
         var expectedObjectType = "Company";
@@ -35,7 +35,7 @@ public sealed class HubSpotAssociationsApiIntegrationTests : HubSpotIntegrationT
     [Fact(Skip = "Depends on the implementation of label API handling")]
     public async Task CreateAssociationByLabelAndFetchToObject()
     {
-        var expectedCompany = CreateTestCompany();
+        var expectedCompany = RecreateTestCompany();
         var expectedContact = RecreateTestContact();
 
         var expectedObjectType = "Company";

--- a/HubSpot.NET.IntegrationTests/Api/Company/HubSpotCompanyApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Company/HubSpotCompanyApiIntegrationTests.cs
@@ -86,6 +86,33 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
         }
     }
 
+    [Fact(Skip = "The API should be upgraded to V3")]
+    public async Task GetCompanyById_WhenAssociationIsPresent_ShouldFetchAssociations()
+    {
+        var expectedCompany = CreateTestCompany();
+        var expectedContact = RecreateTestContact();
+
+        var expectedObjectType = "Company";
+        var expectedObjectId = expectedCompany.Id.Value.ToString();
+        var expectedToObjectType = "Contact";
+        var expectedToObjectId = expectedContact.Id.Value.ToString();
+
+        AssociationsApi.AssociationToObject(expectedObjectType, expectedObjectId, expectedToObjectType,
+            expectedToObjectId);
+
+        // Need to wait for data to be searchable.
+        await Task.Delay(7000);
+
+        var fetchedCompany = CompanyApi.GetById<CompanyHubSpotModel>(expectedCompany.Id.Value);
+
+        using (new AssertionScope())
+        {
+            fetchedCompany.Associations.Should().NotBeNull("Expected to retrieve associations set for the company.");
+            fetchedCompany.Associations.AssociatedContacts.Should().Contain(expectedContact.Id.Value,
+                "The associated contact ID should be present in the retrieved associations.");
+        }
+    }
+
     [Fact]
     public void ListCompanies()
     {

--- a/HubSpot.NET.IntegrationTests/Api/Company/HubSpotCompanyApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Company/HubSpotCompanyApiIntegrationTests.cs
@@ -16,7 +16,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     {
         const string uniqueDomain = "https://www.unique-test-domain.com";
 
-        var createdCompany = CreateTestCompany(website: uniqueDomain);
+        var createdCompany = RecreateTestCompany(website: uniqueDomain);
         var companyByDomain = CompanyApi.GetByDomain<CompanyHubSpotModel>(createdCompany.Domain,
             new CompanySearchByDomain
             {
@@ -44,7 +44,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
         const string expectedCountry = "Test Country";
         const string expectedWebsite = "https://www.test.com";
 
-        var createdCompany = CreateTestCompany(expectedName, expectedCountry, expectedWebsite);
+        var createdCompany = RecreateTestCompany(expectedName, expectedCountry, expectedWebsite);
 
         using (new AssertionScope())
         {
@@ -58,7 +58,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact]
     public void DeleteCompany()
     {
-        var createdCompany = CreateTestCompany();
+        var createdCompany = RecreateTestCompany();
         CompanyApi.Delete(createdCompany.Id.Value);
         CompanyApi.GetById<CompanyHubSpotModel>(createdCompany.Id.Value).Should().BeNull();
     }
@@ -73,7 +73,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact]
     public void GetCompanyById()
     {
-        var createdCompany = CreateTestCompany();
+        var createdCompany = RecreateTestCompany();
 
         var companyById = CompanyApi.GetById<CompanyHubSpotModel>(createdCompany.Id.Value);
         using (new AssertionScope())
@@ -89,7 +89,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact(Skip = "The API should be upgraded to V3")]
     public async Task GetCompanyById_WhenAssociationIsPresent_ShouldFetchAssociations()
     {
-        var expectedCompany = CreateTestCompany();
+        var expectedCompany = RecreateTestCompany();
         var expectedContact = RecreateTestContact();
 
         var expectedObjectType = "Company";
@@ -120,7 +120,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
 
         for (int i = 0; i < 3; i++)
         {
-            var createdCompany = CreateTestCompany($"Test Company {i}", $"Country {i}", $"https://www.test{i}.com");
+            var createdCompany = RecreateTestCompany($"Test Company {i}", $"Country {i}", $"https://www.test{i}.com");
             createdCompanies.Add(createdCompany);
         }
 
@@ -147,7 +147,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact]
     public void UpdateCompany()
     {
-        var createdCompany = CreateTestCompany("Test Company", "Country", "https://www.test.com");
+        var createdCompany = RecreateTestCompany("Test Company", "Country", "https://www.test.com");
 
         createdCompany.Name = "Updated Test Company";
         createdCompany.Country = "Updated Country";
@@ -167,7 +167,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact]
     public async Task SearchCompanies()
     {
-        var createdCompany = CreateTestCompany(name: "Search Test Company");
+        var createdCompany = RecreateTestCompany(name: "Search Test Company");
 
         // Delay is required to allow time for new data to be searchable.
         await Task.Delay(10000);
@@ -206,7 +206,7 @@ public sealed class HubSpotCompanyApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact]
     public async Task GetCompanyAssociations()
     {
-        var createdCompany = CreateTestCompany("Test Company", "Test Country", "https://www.test1.com");
+        var createdCompany = RecreateTestCompany("Test Company", "Test Country", "https://www.test1.com");
         var createdContact = RecreateTestContact("testmail@test1.com", "TestFirstName", "TestLastName");
 
         AssociateContactWithCompany(createdCompany, createdContact); // replace with your actual method

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using HubSpot.NET.Api.Associations;
 using HubSpot.NET.Api.Company;
 using HubSpot.NET.Api.Company.Dto;
 using HubSpot.NET.Api.Contact;
@@ -11,6 +11,7 @@ namespace HubSpot.NET.IntegrationTests;
 public abstract class HubSpotIntegrationTestBase : IDisposable
 {
     private readonly string? ApiKey;
+    protected readonly HubSpotAssociationsApi AssociationsApi;
     protected readonly HubSpotCompanyApi CompanyApi;
     protected readonly HubSpotContactApi ContactApi;
     private readonly HubSpotApi _hubSpotApi;
@@ -31,6 +32,7 @@ public abstract class HubSpotIntegrationTestBase : IDisposable
         ApiKey = configuration["HubSpot:PrivateAppKey"];
 
         var client = new HubSpotBaseClient(ApiKey);
+        AssociationsApi = new HubSpotAssociationsApi(client);
         CompanyApi = new HubSpotCompanyApi(client);
         ContactApi = new HubSpotContactApi(client);
         _hubSpotApi = new HubSpotApi(ApiKey);


### PR DESCRIPTION
## Description
This PR introduces unit tests for `Associations`.

## Tasks
- [x] Integrated unit tests for `Associations`.
- [x] Identified an issue with the `Company` association object when there are no `contacts`. To highlight this problem, a test has been added but is currently skipped.
- [x] Renamed the method `CreateTestCompany` to `RecreateTestCompany` to achieve unique testing data for each test.