### PR TITLE
PD-9426 Integration Tests for ContactLists

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/ContactList/HubSpotContactListApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/ContactList/HubSpotContactListApiIntegrationTests.cs
@@ -36,6 +36,19 @@ public class HubSpotContactListApiIntegrationTests : HubSpotIntegrationTestBase
     }
 
     [Fact]
+    public void ContactListById_WhenDoesNotExist_ShouldBeNull()
+    {
+        var nonExistingId = 0;
+
+        var contactListById = ContactListApi.GetContactListById(nonExistingId);
+
+        using (new AssertionScope())
+        {
+            contactListById.Should().BeNull();
+        }
+    }
+
+    [Fact]
     public void AddContactsToList()
     {
         var (contact1, contact2, contactList) = CreateContactsAndList();
@@ -62,6 +75,20 @@ public class HubSpotContactListApiIntegrationTests : HubSpotIntegrationTestBase
         using (new AssertionScope())
         {
             removalResult.UpdatedContactIds.Should().Contain(new[] { contact1.Id.Value, contact2.Id.Value });
+        }
+    }
+
+    [Fact]
+    public void DeleteContactList()
+    {
+        var createdContactList = RecreateTestContactList("StaticTestList");
+        ContactListApi.DeleteContactList(createdContactList.ListId);
+
+        var deletedContactList = ContactListApi.GetContactListById(createdContactList.ListId);
+
+        using (new AssertionScope())
+        {
+            deletedContactList.Should().BeNull();
         }
     }
 

--- a/HubSpot.NET.IntegrationTests/Api/ContactList/HubSpotContactListApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/ContactList/HubSpotContactListApiIntegrationTests.cs
@@ -92,6 +92,47 @@ public class HubSpotContactListApiIntegrationTests : HubSpotIntegrationTestBase
         }
     }
 
+    [Fact]
+    public async Task GetContactLists()
+    {
+        var createdContactList1 = RecreateTestContactList("TestList1");
+        var createdContactList2 = RecreateTestContactList("TestList2");
+
+        // to make data searchable
+        await Task.Delay(10000);
+
+        var contactLists = ContactListApi.GetContactLists().Lists;
+
+        using (new AssertionScope())
+        {
+            contactLists.Should().NotBeNull();
+            contactLists.Should().Contain(c => c.ListId == createdContactList1.ListId);
+            contactLists.Should().Contain(c => c.ListId == createdContactList2.ListId);
+        }
+    }
+
+    // Note: The HubSpotContactListApi currently only allows for the creation of static lists,
+    // which is why these tests are designed around them. If future updates to the library
+    // add the ability to create dynamic lists, these tests should be revised to account for that.
+    [Fact]
+    public async Task GetStaticContactLists()
+    {
+        var createdContactList1 = RecreateTestContactList("StaticTestList1");
+        var createdContactList2 = RecreateTestContactList("StaticTestList2");
+
+        // to make data searchable
+        await Task.Delay(10000);
+
+        var contactLists = ContactListApi.GetStaticContactLists().Lists;
+
+        using (new AssertionScope())
+        {
+            contactLists.Should().NotBeNull();
+            contactLists.Should().Contain(c => c.ListId == createdContactList1.ListId);
+            contactLists.Should().Contain(c => c.ListId == createdContactList2.ListId);
+        }
+    }
+
     private (ContactHubSpotModel contact1, ContactHubSpotModel contact2, ContactListModel contactList)
         CreateContactsAndList()
     {

--- a/HubSpot.NET.IntegrationTests/Api/ContactList/HubSpotContactListApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/ContactList/HubSpotContactListApiIntegrationTests.cs
@@ -1,0 +1,79 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using HubSpot.NET.Api.Contact.Dto;
+using HubSpot.NET.Api.ContactList.Dto;
+
+namespace HubSpot.NET.IntegrationTests.Api.ContactList;
+
+public class HubSpotContactListApiIntegrationTests : HubSpotIntegrationTestBase
+{
+    [Fact]
+    public void CreateStaticContactList()
+    {
+        var expectedContactListName = "StaticTestList";
+        var createdContactList = RecreateTestContactList(expectedContactListName);
+
+        using (new AssertionScope())
+        {
+            createdContactList.Should().NotBeNull();
+            createdContactList.Name.Should().Be(expectedContactListName);
+            createdContactList.Dynamic.Should().Be(false);
+        }
+    }
+
+    [Fact]
+    public void GetContactListById()
+    {
+        var createdContactList = RecreateTestContactList("StaticTestList");
+        var contactListById = ContactListApi.GetContactListById(createdContactList.ListId);
+
+        using (new AssertionScope())
+        {
+            contactListById.Should().NotBeNull();
+            contactListById.ListId.Should().Be(createdContactList.ListId);
+            contactListById.Name.Should().Be(createdContactList.Name);
+        }
+    }
+
+    [Fact]
+    public void AddContactsToList()
+    {
+        var (contact1, contact2, contactList) = CreateContactsAndList();
+
+        var additionResult =
+            ContactListApi.AddContactsToList(contactList.ListId, new[] { contact1.Id.Value, contact2.Id.Value });
+
+        using (new AssertionScope())
+        {
+            additionResult.UpdatedContactIds.Should().Contain(new[] { contact1.Id.Value, contact2.Id.Value });
+        }
+    }
+
+    [Fact]
+    public void RemoveContactsFromList()
+    {
+        var (contact1, contact2, contactList) = CreateContactsAndList();
+
+        ContactListApi.AddContactsToList(contactList.ListId, new[] { contact1.Id.Value, contact2.Id.Value });
+
+        var removalResult =
+            ContactListApi.RemoveContactsFromList(contactList.ListId, new[] { contact1.Id.Value, contact2.Id.Value });
+
+        using (new AssertionScope())
+        {
+            removalResult.UpdatedContactIds.Should().Contain(new[] { contact1.Id.Value, contact2.Id.Value });
+        }
+    }
+
+    private (ContactHubSpotModel contact1, ContactHubSpotModel contact2, ContactListModel contactList)
+        CreateContactsAndList()
+    {
+        var createdContact1 = RecreateTestContact("createdcontact1@test.com", "FirstName1", "LastName1", "TestCompany1",
+            "1234567891");
+        var createdContact2 = RecreateTestContact("createdcontact2@test.com", "FirstName2", "LastName2", "TestCompany2",
+            "1234567892");
+        var createdContactList = RecreateTestContactList("StaticTestList");
+
+        return (createdContact1, createdContact2, createdContactList);
+    }
+}

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
@@ -172,41 +172,49 @@ public abstract class HubSpotIntegrationTestBase : IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        if (!_isDisposed)
+        if (_isDisposed || !disposing)
+            return;
+
+        CleanCompanies();
+        CleanContacts();
+        CleanContactLists();
+
+        _isDisposed = true;
+    }
+
+    private void CleanCompanies()
+    {
+        foreach (var companyId in _companiesToCleanup)
         {
-            if (disposing)
-            {
-                foreach (var companyId in _companiesToCleanup)
-                {
-                    CompanyApi.Delete(companyId);
-                }
+            CompanyApi.Delete(companyId);
+        }
+    }
 
-                foreach (var contactId in _contactsToCleanup)
-                {
-                    try
-                    {
-                        ContactApi.Delete(contactId);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-                }
+    private void CleanContacts()
+    {
+        foreach (var contactId in _contactsToCleanup)
+        {
+            TryAction(() => ContactApi.Delete(contactId));
+        }
+    }
 
-                foreach (var contactListId in _contactListToCleanup)
-                {
-                    try
-                    {
-                        ContactListApi.DeleteContactList(contactListId);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-                }
-            }
+    private void CleanContactLists()
+    {
+        foreach (var contactListId in _contactListToCleanup)
+        {
+            TryAction(() => ContactListApi.DeleteContactList(contactListId));
+        }
+    }
 
-            _isDisposed = true;
+    private void TryAction(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch
+        {
+            // ignored
         }
     }
 

--- a/HubSpot.NET/Api/ContactList/HubSpotContactListApi.cs
+++ b/HubSpot.NET/Api/ContactList/HubSpotContactListApi.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Net;
 using HubSpot.NET.Api.ContactList.Dto;
+using HubSpot.NET.Core;
 using HubSpot.NET.Core.Extensions;
 using HubSpot.NET.Core.Interfaces;
 using RestSharp;
@@ -79,11 +81,20 @@ namespace HubSpot.NET.Api.ContactList
         /// <returns>The data</returns>
         public ContactListModel GetContactListById(long contactListId)
         {
-            var path = $"{new ContactListModel().RouteBasePath}/{contactListId}";
+            try
+            {
+                var path = $"{new ContactListModel().RouteBasePath}/{contactListId}";
 
-            var data = _client.ExecuteList<ContactListModel>(path, convertToPropertiesSchema: false);
+                var data = _client.ExecuteList<ContactListModel>(path, convertToPropertiesSchema: false);
 
-            return data;
+                return data;
+            }
+            catch (HubSpotException exception)
+            {
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This PR introduces unit tests for ContactLists.

## Tasks
- [x] Integrated unit tests for ContactLists methods, ensuring both `GetContactLists` and `GetStaticContactLists` are properly tested.
- [x] Implemented and utilized `RecreateTestContactList` to create unique static contact lists for each test.
- [x] Refactored `Dispose()` to reduce cognitive complexity.
- [x] Fine-tuned 'GetContactListById' to handle edge cases gracefully by allowing null returns when no records are found.
- [x] Identified an inconsistency in the `HubSpotContactListApi`, where only static contact lists can be created. This has been documented in the test comments. Future library updates should consider supporting dynamic contact list creation.

## Inconsistency with `HubSpotContactListApi`
Whilst developing these tests, it was revealed that the `HubSpotContactListApi` only allows for creating static lists. However, the API provides two methods for retrieving lists: `GetContactLists` and `GetStaticContactLists`. Making a note of this for future need of enhancements in the library.
