### PR TITLE
PD-9426 Integration Tests for Company Properties

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/Properties/HubSpotCompanyPropertiesApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Properties/HubSpotCompanyPropertiesApiIntegrationTests.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace HubSpot.NET.IntegrationTests.Api.Properties;
+
+public class HubSpotCompanyPropertiesApiIntegrationTests : HubSpotIntegrationTestBase
+{
+    [Fact(Skip = "This test requires CreatePropertyGroup implementation")]
+    public async Task Create()
+    {
+        const string expectedName = "TestProperty";
+        const string expectedType = "string";
+        const string expectedFieldType = "text";
+        const string expectedGroup = "TestGroup";
+        const string expectedLabel = "TestLabel";
+
+        var createdCompanyProperty =
+            RecreateTestCompanyProperty(name: expectedName, type: expectedType, fieldType: expectedFieldType,
+                groupName: expectedGroup, label: expectedLabel);
+
+        using (new AssertionScope())
+        {
+            createdCompanyProperty.Should().NotBeNull();
+            createdCompanyProperty.Name.Should().Be(expectedName);
+            createdCompanyProperty.Type.Should().Be(expectedType);
+            createdCompanyProperty.FieldType.Should().Be(expectedFieldType);
+        }
+    }
+
+    [Fact(Skip = "This test requires CreatePropertyGroup implementation")]
+    public void GetAll()
+    {
+        var createdCompanyProperty1 =
+            RecreateTestCompanyProperty(name: "TestProperty1", type: "string", fieldType: "text");
+        var createdCompanyProperty2 =
+            RecreateTestCompanyProperty(name: "TestProperty2", type: "string", fieldType: "text");
+
+        var allProperties = CompanyPropertiesApi.GetAll().Results;
+
+        using (new AssertionScope())
+        {
+            allProperties.Should().NotBeNull();
+            allProperties.Count.Should()
+                .BeGreaterOrEqualTo(2);
+            allProperties.Should().Contain(p => p.Name == createdCompanyProperty1.Name);
+            allProperties.Should().Contain(p => p.Name == createdCompanyProperty2.Name);
+        }
+    }
+}

--- a/HubSpot.NET.IntegrationTests/Api/Properties/HubSpotCompanyPropertiesApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Properties/HubSpotCompanyPropertiesApiIntegrationTests.cs
@@ -1,12 +1,13 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Execution;
+using HubSpot.NET.Core;
 
 namespace HubSpot.NET.IntegrationTests.Api.Properties;
 
 public class HubSpotCompanyPropertiesApiIntegrationTests : HubSpotIntegrationTestBase
 {
     [Fact(Skip = "This test requires CreatePropertyGroup implementation")]
-    public async Task Create()
+    public void Create()
     {
         const string expectedName = "TestProperty";
         const string expectedType = "string";
@@ -45,5 +46,12 @@ public class HubSpotCompanyPropertiesApiIntegrationTests : HubSpotIntegrationTes
             allProperties.Should().Contain(p => p.Name == createdCompanyProperty1.Name);
             allProperties.Should().Contain(p => p.Name == createdCompanyProperty2.Name);
         }
+    }
+
+    [Fact]
+    public void GetAll_ShouldNotThrowException()
+    {
+        var act = () => CompanyPropertiesApi.GetAll().Results;
+        act.Should().NotThrow<HubSpotException>();
     }
 }

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
@@ -164,11 +164,11 @@ public abstract class HubSpotIntegrationTestBase : IDisposable
     }
 
     protected CompanyPropertyHubSpotModel RecreateTestCompanyProperty(string name = "TestPropertyName",
-        string type = "string", string fieldType = "text")
+        string type = "string", string fieldType = "text", string groupName = "TestGroup", string label = "TestLabel")
     {
-        var allProperties = CompanyPropertiesApi.GetAll();
+        var allProperties = CompanyPropertiesApi.GetAll().Results;
 
-        var existingProperty = allProperties.FirstOrDefault(p => p.Name == name);
+        var existingProperty = allProperties.Find(p => p.Name == name);
 
         if (existingProperty != null)
         {
@@ -179,7 +179,9 @@ public abstract class HubSpotIntegrationTestBase : IDisposable
         {
             Name = name,
             Type = type,
-            FieldType = fieldType
+            FieldType = fieldType,
+            GroupName = groupName,
+            Label = label
         };
 
         var createdProperty = CompanyPropertiesApi.Create(newProperty);

--- a/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
@@ -1,74 +1,31 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using HubSpot.NET.Core.Interfaces;
 
-namespace HubSpot.NET.Api.Properties.Dto
+namespace HubSpot.NET.Api.Properties.Dto;
+
+[DataContract]
+public class PropertiesListHubSpotModel<T> : IHubSpotModel where T : IHubSpotModel
 {
+    [DataMember(Name = "results")] public List<T> Results { get; set; }
 
-    /// <summary>
-    /// Models a set of properties in HubSpot (contacts, companies etc.)
-    /// </summary>
-    [DataContract]
-    public class PropertiesListHubSpotModel<T> : IHubSpotModel, ICollection<T> where T : IHubSpotModel
+    public string RouteBasePath
     {
-        private List<T> Properties { get; } = new List<T>();
-
-        public string RouteBasePath
+        get
         {
-            get
-            {
-                var entity = (T)Activator.CreateInstance(typeof(T));
-                return "crm/v3/properties" + entity.RouteBasePath;
-            }
+            var entity = (T)Activator.CreateInstance(typeof(T));
+            return "crm/v3/properties" + entity.RouteBasePath;
         }
+    }
 
-        public bool IsNameValue => false;
-        public virtual void ToHubSpotDataEntity(ref dynamic converted)
-        {
-        }
+    public bool IsNameValue => false;
 
-        public virtual void FromHubSpotDataEntity(dynamic hubspotData)
-        {
-        }
+    public virtual void ToHubSpotDataEntity(ref dynamic dataEntity)
+    {
+    }
 
-        public IEnumerator<T> GetEnumerator()
-        {
-            return Properties.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        public void Add(T item)
-        {
-            Properties.Add(item);
-        }
-
-        public void Clear()
-        {
-            Properties.Clear();
-        }
-
-        public bool Contains(T item)
-        {
-            return Properties.Contains(item);
-        }
-
-        public void CopyTo(T[] array, int arrayIndex)
-        {
-            Properties.CopyTo(array, arrayIndex);
-        }
-
-        public bool Remove(T item)
-        {
-            return Properties.Remove(item);
-        }
-
-        public int Count => Properties.Count;
-        public bool IsReadOnly => false;
+    public virtual void FromHubSpotDataEntity(dynamic hubspotData)
+    {
     }
 }


### PR DESCRIPTION
## Description
<!-- Explain the changes you have made and why they are significant -->
This PR introduces unit tests for Company Properties. However, the code was not fully implemented and failed during execution. To address this, the model class for Company Properties was refactored, enabling the code to return a list of CompanyProperties. Currently, it's not possible to set up entities to test the search and create methods. Integration test cases have been introduced but are skipped, pending the implementation of other groups' functionality.

## Purpose
- [X] Made `GetAll()` function properly with API V3.
- [X] Added integration tests for Company Properties.

