### PR TITLE
PD-9426 Integration Tests for Custom Objects

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotContactApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotContactApiIntegrationTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using HubSpot.NET.Api.CustomObject;
+using HubSpot.NET.Core;
+
+namespace HubSpot.NET.IntegrationTests.Api.CustomObject;
+
+public sealed class HubSpotCustomObjectApiIntegrationTests : HubSpotIntegrationTestBase
+{
+    [Fact]
+    public void List_GivenUnknownObjectId_ShouldThrowException()
+    {
+        const string idForCustomObject = "unknown_known_custom_object_id";
+        var opts = new ListRequestOptions();
+
+        var act = () => CustomObjectApi.List<CustomObjectHubSpotModel>(idForCustomObject, opts).Results;
+        act.Should().Throw<HubSpotException>()
+            .WithMessage("*Unable to infer object type from: unknown_known_custom_object_id*");
+    }
+
+    [Fact(Skip = "Setup your own CustomObject and provide an ID for it.")]
+    public void List_GivenExistingObject_ShouldGetResults()
+    {
+        // Arrange a custom object at https://app.hubspot.com/ with a property
+        const string customProperty = "machine_name";
+        const string idForCustomObject = "2-29369202";
+
+        var opts = new ListRequestOptions
+        {
+            Limit = 2,
+            PropertiesToInclude = new List<string> { "hs_created_by_user_id", customProperty }
+        };
+
+        var customObjectList = CustomObjectApi.List<CustomObjectHubSpotModel>(idForCustomObject, opts).Results;
+
+        customObjectList.Should().NotBeNull();
+    }
+}

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
@@ -6,6 +6,7 @@ using HubSpot.NET.Api.Contact;
 using HubSpot.NET.Api.Contact.Dto;
 using HubSpot.NET.Api.ContactList;
 using HubSpot.NET.Api.ContactList.Dto;
+using HubSpot.NET.Api.CustomObject;
 using HubSpot.NET.Api.Properties;
 using HubSpot.NET.Api.Properties.Dto;
 using HubSpot.NET.Core;
@@ -23,6 +24,7 @@ public abstract class HubSpotIntegrationTestBase : IDisposable
     protected readonly HubSpotContactApi ContactApi;
     protected readonly HubSpotContactListApi ContactListApi;
     protected readonly HubSpotCompaniesPropertiesApi CompanyPropertiesApi;
+    protected readonly HubSpotCustomObjectApi CustomObjectApi;
 
     private readonly HubSpotApi _hubSpotApi;
 
@@ -49,6 +51,7 @@ public abstract class HubSpotIntegrationTestBase : IDisposable
         ContactApi = new HubSpotContactApi(client);
         ContactListApi = new HubSpotContactListApi(client);
         CompanyPropertiesApi = new HubSpotCompaniesPropertiesApi(client);
+        CustomObjectApi = new HubSpotCustomObjectApi(client, AssociationsApi);
         _hubSpotApi = new HubSpotApi(ApiKey);
     }
 


### PR DESCRIPTION
## Description
<!-- Tell us a little bit about the changes you have made and why you think they are important -->
This PR introduces unit tests for `Custom Objects`. However, the code implements only a few methods to interact with this entity so it is not possible to create a new custom object schema and try out all the implemented methods. Given that at the time being we do not need custom objects - it implements the only possible test of finding a non-existent `Custom Object`. 

Besides, it adds a test that fetches an existing `Custom Object`, but you need to provide it with your own `Custom Object Id`.
## Purpose
- [x] Add tests for `List()` method.