### PR TITLE
PD-9426 Add collections to avoid flaky tests

### DIFF
--- a/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
@@ -9,6 +9,7 @@ using SearchRequestFilterGroup = HubSpot.NET.Api.SearchRequestFilterGroup;
 
 namespace HubSpot.NET.IntegrationTests;
 
+[Collection("Integration tests collection")]
 public abstract class HubSpotAsyncIntegrationTestBase : HubSpotIntegrationTestSetup
 {
     protected async Task<CompanyHubSpotModel> RecreateTestCompanyAsync(string name = "Test Company",

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
@@ -9,6 +9,7 @@ using SearchRequestFilterGroup = HubSpot.NET.Api.SearchRequestFilterGroup;
 
 namespace HubSpot.NET.IntegrationTests;
 
+[Collection("Integration tests collection")]
 public abstract class HubSpotIntegrationTestBase : HubSpotIntegrationTestSetup
 {
     protected CompanyHubSpotModel RecreateTestCompany(string name = "Test Company", string country = "Test Country",


### PR DESCRIPTION
## Description
<!-- Tell us a little bit about the changes you have made and why you think they are important -->
Test collections have been added to isolate individual tests and prevent setup conflicts. This significantly improves the reliability of tests by eliminating flaky, inconsistently passing/failing tests.

## Purpose
- [x] Added test collections
