### PR TITLE
PD-9426 Target frameworks netstandart2.1 and net48

### DIFF
--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>HubSpot.NET;PowerDiary</Authors>
     <Company>PowerDiary</Company>
     <Description>.NET client library targeting the HubSpot APIs.</Description>
@@ -12,16 +12,17 @@
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm custom objects</PackageTags>
     <PackageReleaseNotes>1.0.0</PackageReleaseNotes>
     <PackageId>PowerDiary.HubSpot.NET</PackageId>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>1.0.2</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>8</LangVersion>
+    <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/HubSpot.NET/HubSpot.NET.nuspec
+++ b/HubSpot.NET/HubSpot.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>PowerDiary.HubSpot.NET</id>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <title>PowerDiary's Fork of HubSpot.NET</title>
     <authors>PowerDiary</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <!-- <icon>icon.png</icon> -->
     <projectUrl>https://github.com/powerdiary/HubSpot.NET</projectUrl>
     <description>This is PowerDiary's custom fork of HubSpot.NET. This library modification includes adding support for asynchronous methods and upgrading the RestSharp and Newtonsoft.Net libraries. It also addresses several identified issues in the code.</description>
-    <releaseNotes>Downgraded from C# 10 to C# 8; Target set to netstandard2.1.</releaseNotes>
+    <releaseNotes>Target set to netstandard2.1 and net48.</releaseNotes>
     <copyright>Copyright © PowerDiary Ltd 2024</copyright>
     <tags>HubSpot PowerDiary HubSpot.NET</tags>
   </metadata>


### PR DESCRIPTION
## Description
<!-- Tell us a little bit about the changes you have made and why you think they are important -->
The package version has been updated from 1.0.1 to 1.0.2. Changes in the code also included the addition of framework `net48` to the target frameworks, and the inclusion of package reference for System.Net.Http version 4.3.4. These changes will provide more versatility for this library regarding compatibility with different .NET versions.

## Purpose
- [x] Target `net48` in addition to `netstandard2.1`