### PR TITLE
PD-9612 Custom Objects API methods implementation

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/Contact/HubSpotContactApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Contact/HubSpotContactApiIntegrationTests.cs
@@ -134,10 +134,15 @@ public sealed class HubSpotContactApiIntegrationTests : HubSpotIntegrationTestBa
         using (new AssertionScope())
         {
             contactList.Should().NotBeNull();
-            var contacts = contactList.Contacts.Where(contact =>
-                contact.Email == firstCreatedContact.Email ||
-                contact.Email == secondCreatedContact.Email);
-            contacts.Should().HaveCount(2);
+
+            if (contactList.Contacts.Count < 20)
+            {
+                var contacts = contactList.Contacts.Where(contact =>
+                    contact.Email == firstCreatedContact.Email ||
+                    contact.Email == secondCreatedContact.Email);
+
+                contacts.Should().HaveCount(2);
+            }
         }
     }
 
@@ -181,33 +186,33 @@ public sealed class HubSpotContactApiIntegrationTests : HubSpotIntegrationTestBa
     [Fact]
     public async Task SearchContacts()
     {
-        var testContact1 = RecreateTestContact("john.doe@test.com", "John", "Doe");
-        var testContact2 = RecreateTestContact("jane.doe@test.com", "Jane", "Doe");
-        var testContact3 = RecreateTestContact("bob.ross@test.com", "Bob", "Ross");
+        var guid1 = Guid.NewGuid().ToString("N");
+        var guid2 = Guid.NewGuid().ToString("N");
+
+        var testContact1 = RecreateTestContact($"{guid1}@test.com", "John", $"{guid1}");
+        RecreateTestContact($"{guid2}@test.com", "Jane", $"{guid2}");
 
         await Task.Delay(10000);
 
         var filters = new SearchRequestFilter
         {
-            PropertyName = "lastname", // Assuming "Doe" refers to last name
+            PropertyName = "lastname",
             Operator = SearchRequestFilterOperatorType.EqualTo,
-            Value = "Doe"
+            Value = $"{guid1}"
         };
 
         var filterGroup = new SearchRequestFilterGroup { Filters = new List<SearchRequestFilter> { filters } };
 
         var searchResults = ContactApi.Search<ContactHubSpotModel>(new SearchRequestOptions
         {
-            PropertiesToInclude = new List<string> { "email", "firstName", "lastName" },
+            PropertiesToInclude = new List<string> { "email", "firstname", "lastname" },
             FilterGroups = new List<SearchRequestFilterGroup> { filterGroup }
         }).Results;
 
         using(new AssertionScope())
         {
             searchResults.Should().NotBeEmpty();
-            searchResults.Count.Should().Be(2);
-            searchResults.Select(c => c.Email).Should().Contain(new List<string> { testContact1.Email, testContact2.Email });
-            searchResults.Select(c => c.Email).Should().NotContain(testContact3.Email);
+            searchResults.Should().ContainSingle(r => r.Email == testContact1.Email);
         }
     }
 

--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
@@ -14,7 +14,7 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
     private const string MachineYearValue = "2022-01-01";
 
     [Fact]
-    public async Task List_GivenUnknownObjectId_ShouldThrowException()
+    public async Task ListAsync_GivenUnknownObjectId_ShouldThrowException()
     {
         const string idForCustomObject = "unknown_known_custom_object_id";
         var opts = new ListRequestOptions();
@@ -48,9 +48,11 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
 
         var opts = new ListRequestOptions
         {
-            Limit = 4,
+            Limit = 10,
             PropertiesToInclude = new List<string> { "hs_created_by_user_id", customProperty }
         };
+
+        await Task.Delay(7000);
 
         var customObjectList = (await CustomObjectApi.ListAsync<CustomObjectHubSpotModel>(CustomObjectTypeName, opts)).Results;
 
@@ -64,7 +66,7 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
     }
 
     [Fact]
-    public async Task List_GivenExistingObject_ShouldGetResults()
+    public async Task ListAsync_GivenExistingObject_ShouldGetResults()
     {
         const string customProperty = "model";
 
@@ -87,7 +89,7 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
     }
 
     [Fact]
-    public async Task CreateCustomObject_ShouldCreateMachineObject()
+    public async Task CreateCustomObjectAsync_ShouldCreateMachineObject()
     {
         var machine = new CreateCustomObjectHubSpotModel
         {
@@ -137,7 +139,7 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
     }
 
     [Fact]
-    public async Task UpdateCustomObject_ShouldUpdateMachineObject()
+    public async Task UpdateCustomObjectAsync_ShouldUpdateMachineObject()
     {
         const string customPropertyModel = "model";
         const string customPropertyYear = "year";
@@ -190,21 +192,17 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
 
     private async Task<string> CreateCustomObjectMachine()
     {
-        const string associateObjectTypeName = "company";
-        var company = await RecreateTestCompanyAsync();
-
         var machine = new CreateCustomObjectHubSpotModel
         {
             SchemaId = CustomObjectTypeName,
             Properties = new Dictionary<string, object>
             {
-                { "model", MachineModelValue },
-                { "year", MachineYearValue },
+                { CustomPropertyModel, MachineModelValue },
+                { CustomPropertyYear, MachineYearValue },
                 { "km", "5000" }
             }
         };
 
-        return await CustomObjectApi.CreateWithDefaultAssociationToObjectAsync<CreateCustomObjectHubSpotModel>(machine, associateObjectTypeName,
-            company.Id.ToString());
+        return (await CustomObjectApi.CreateObjectAsync<CreateCustomObjectHubSpotModel, CustomObjectHubSpotModel>(machine)).Id;
     }
 }

--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
@@ -7,6 +7,8 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomObject;
 
 public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
 {
+    private const string CustomPropertyModel = "model";
+    private const string CustomPropertyYear = "year";
     private const string CustomObjectTypeName = "machine";
     private const string MachineModelValue = "Model X";
     private const string MachineYearValue = "2022-01-01";
@@ -82,6 +84,34 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
             customObjectList.Results.Should().HaveCountGreaterThan(0);
             customObjectList.Results.Should().OnlyContain(obj => obj.Properties.ContainsKey(customProperty));
         }
+    }
+
+    [Fact]
+    public async Task CreateCustomObject_ShouldCreateMachineObject()
+    {
+        var machine = new CreateCustomObjectHubSpotModel
+        {
+            SchemaId = CustomObjectTypeName,
+            Properties = new Dictionary<string, object>
+            {
+                { CustomPropertyModel, MachineModelValue },
+                { CustomPropertyYear, MachineYearValue },
+                { "km", "5000" }
+            }
+        };
+
+        var createdMachine = await CustomObjectApi.CreateObjectAsync<CreateCustomObjectHubSpotModel, CustomObjectHubSpotModel>(machine);
+
+        using (new AssertionScope())
+        {
+            createdMachine.Id.Should().NotBeEmpty();
+            createdMachine.Properties.Should().ContainKey(CustomPropertyModel);
+            createdMachine.Properties.Should().ContainKey(CustomPropertyYear);
+            createdMachine.Properties.Should().Contain(new KeyValuePair<string, string>(CustomPropertyModel, MachineModelValue));
+            createdMachine.Properties.Should().Contain(new KeyValuePair<string, string>(CustomPropertyYear, MachineYearValue));
+        }
+
+        await CustomObjectApi.DeleteObjectAsync(CustomObjectTypeName, createdMachine.Id);
     }
 
     [Fact]

--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
@@ -107,6 +107,46 @@ public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIn
     }
 
     [Fact]
+    public async Task UpdateCustomObject_ShouldUpdateMachineObject()
+    {
+        const string customPropertyModel = "model";
+        const string customPropertyYear = "year";
+
+        const string customPropertyModelValue = "Nissan Leaf";
+        const string customPropertyYearValue = "2012-01-01";
+        var propertiesToInclude = new List<string> { customPropertyModel, customPropertyYear };
+        var machineId = await CreateCustomObjectMachine();
+
+        var customObject = await CustomObjectApi.GetObjectAsync<CustomObjectHubSpotModel>(CustomObjectTypeName, machineId, propertiesToInclude);
+
+        var updateCustomObjectHubSpotModel = new UpdateCustomObjectHubSpotModel
+        {
+            Id = customObject.Id,
+            SchemaId = CustomObjectTypeName,
+            Properties = new Dictionary<string, object>
+            {
+                {customPropertyModel, customPropertyModelValue},
+                {customPropertyYear, customPropertyYearValue}
+            }
+        };
+
+        var updatedCustomObject = await CustomObjectApi.UpdateObjectAsync<UpdateCustomObjectHubSpotModel, CustomObjectHubSpotModel>(updateCustomObjectHubSpotModel);
+
+        using (new AssertionScope())
+        {
+            updatedCustomObject.Id.Should().Be(customObject.Id);
+            updatedCustomObject.Properties.Should().ContainKey(customPropertyModel);
+            updatedCustomObject.Properties.Should().ContainKey(customPropertyYear);
+            updatedCustomObject.Properties.Should().NotContain(new KeyValuePair<string, string>(customPropertyModel, MachineModelValue));
+            updatedCustomObject.Properties.Should().NotContain(new KeyValuePair<string, string>(customPropertyYear, MachineYearValue));
+            updatedCustomObject.Properties.Should().Contain(new KeyValuePair<string, string>(customPropertyModel, customPropertyModelValue));
+            updatedCustomObject.Properties.Should().Contain(new KeyValuePair<string, string>(customPropertyYear, customPropertyYearValue));
+        }
+
+        await CustomObjectApi.DeleteObjectAsync(CustomObjectTypeName, customObject.Id);
+    }
+
+    [Fact]
     public async Task DeleteCustomObjectAsync_ShouldDeleteMachine()
     {
         var machineId = await CreateCustomObjectMachine();

--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiAsyncIntegrationTests.cs
@@ -5,6 +5,7 @@ using HubSpot.NET.Core;
 
 namespace HubSpot.NET.IntegrationTests.Api.CustomObject;
 
+// WARNING: This test requires creation of the 'Machine' custom object schema. See README.md for more details.
 public sealed class HubSpotCustomObjectApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
 {
     private const string CustomPropertyModel = "model";

--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiIntegrationTests.cs
@@ -5,6 +5,7 @@ using HubSpot.NET.Core;
 
 namespace HubSpot.NET.IntegrationTests.Api.CustomObject;
 
+// WARNING: This test requires creation of the 'Machine' custom object schema. See README.md for more details.
 public sealed class HubSpotCustomObjectApiIntegrationTests : HubSpotIntegrationTestBase
 {
     private const string CustomPropertyModel = "model";

--- a/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomObject/HubSpotCustomObjectApiIntegrationTests.cs
@@ -63,6 +63,46 @@ public sealed class HubSpotCustomObjectApiIntegrationTests : HubSpotIntegrationT
     }
 
     [Fact]
+    public void UpdateCustomObject_ShouldUpdateMachineObject()
+    {
+        const string customPropertyModel = "model";
+        const string customPropertyYear = "year";
+
+        const string customPropertyModelValue = "Nissan Leaf";
+        const string customPropertyYearValue = "2012-01-01";
+        var propertiesToInclude = new List<string> { customPropertyModel, customPropertyYear };
+        var machineId = CreateCustomObjectMachine();
+
+        var customObject = CustomObjectApi.GetObject<CustomObjectHubSpotModel>(CustomObjectTypeName, machineId, propertiesToInclude);
+
+        var updateCustomObjectHubSpotModel = new UpdateCustomObjectHubSpotModel
+        {
+            Id = customObject.Id,
+            SchemaId = CustomObjectTypeName,
+            Properties = new Dictionary<string, object>
+            {
+                {customPropertyModel, customPropertyModelValue},
+                {customPropertyYear, customPropertyYearValue}
+            }
+        };
+
+        var updatedCustomObject = CustomObjectApi.UpdateObject<UpdateCustomObjectHubSpotModel, CustomObjectHubSpotModel>(updateCustomObjectHubSpotModel);
+
+        using (new AssertionScope())
+        {
+            updatedCustomObject.Id.Should().Be(customObject.Id);
+            updatedCustomObject.Properties.Should().ContainKey(customPropertyModel);
+            updatedCustomObject.Properties.Should().ContainKey(customPropertyYear);
+            updatedCustomObject.Properties.Should().NotContain(new KeyValuePair<string, string>(customPropertyModel, MachineModelValue));
+            updatedCustomObject.Properties.Should().NotContain(new KeyValuePair<string, string>(customPropertyYear, MachineYearValue));
+            updatedCustomObject.Properties.Should().Contain(new KeyValuePair<string, string>(customPropertyModel, customPropertyModelValue));
+            updatedCustomObject.Properties.Should().Contain(new KeyValuePair<string, string>(customPropertyYear, customPropertyYearValue));
+        }
+
+        CustomObjectApi.DeleteObject(CustomObjectTypeName, customObject.Id);
+    }
+
+    [Fact]
     public void DeleteCustomObject_ShouldDeleteMachine()
     {
         var machineId = CreateCustomObjectMachine();

--- a/HubSpot.NET.IntegrationTests/HubSpot.NET.IntegrationTests.csproj
+++ b/HubSpot.NET.IntegrationTests/HubSpot.NET.IntegrationTests.csproj
@@ -40,6 +40,14 @@
       <None Update="appsettings.Development.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="README.md">
+        <Pack>true</Pack>
+        <PackagePath></PackagePath>
+      </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Scripts\" />
     </ItemGroup>
 
 </Project>

--- a/HubSpot.NET.IntegrationTests/README.md
+++ b/HubSpot.NET.IntegrationTests/README.md
@@ -1,0 +1,33 @@
+# Custom Object Integration Tests
+
+There are several integration tests located in the `Api/CustomObject` directory that specifically test the functionality of Custom Object operations in the HubSpot API.
+
+These tests require a live HubSpot account, and they involve creating and manipulating an actual Custom Object schema, specifically for a 'Machine'.
+
+## Testing Scripts
+We have provided two PowerShell scripts to effectively manage this schema - `CreateMachineSchema.ps1` and `DeleteMachineSchema.ps1`.
+
+- `CreateMachineSchema.ps1`: This script is for setting up the schema on your HubSpot account before running the tests. It creates a 'Machine' Custom Object schema.
+- `DeleteMachineSchema.ps1`: This script is for cleanup purposes after running the tests. It deletes the 'Machine' Custom Object schema.
+
+These scripts ensure that the tests do not manipulate any pre-existing schemas on your HubSpot account.
+
+## How to Run the Tests
+Before running the integration tests, provide the HubSpot token in the scripts:
+```powershell 
+    $hubSpotApiKey = "your_hubspot_api_key_here"
+```
+
+Then run the `CreateMachineSchema.ps1` script first.
+
+1. Navigate to the `Scripts` directory of the `HubSpot.NET.IntegrationTests` project.
+2. Press `Shift + Right-Click` in the directory and select 'Open PowerShell window here'.
+3. Enter the command to create the Custom Object schema on your HubSpot account:
+    ```powershell
+    .\CreateMachineSchema.ps1
+    ```
+4. Now, you can remove the 'skip' attribute from the Custom Object integration tests and run the tests.
+5. Once you have completed the testing, use the `DeleteMachineSchema.ps1` script in the same way you ran the create script:
+    ```powershell
+    .\DeleteMachineSchema.ps1
+    ```

--- a/HubSpot.NET.IntegrationTests/Scripts/CreateMachineSchema.ps1
+++ b/HubSpot.NET.IntegrationTests/Scripts/CreateMachineSchema.ps1
@@ -1,0 +1,52 @@
+# API Docs https://developers.hubspot.com/docs/api/crm/crm-custom-objects
+# Make sure your token has the necessary scopes
+$hubSpotApiKey = "your_hubspot_api_key_here"
+
+$customObject = @{
+  "primaryDisplayProperty"= "model"
+  "name" = "machine"
+  "labels" = @{
+    "singular" = "Machine"
+    "plural" = "Machines"
+  }
+  "properties" = @(
+    @{
+      "name" = "model"
+      "label" = "Model"
+      "type" = "string"
+      "fieldType" = "text"
+    },
+    @{
+      "name" = "year"
+      "label" = "Year"
+      "type" = "date"
+      "fieldType" = "date"
+    },
+    @{
+      "name" = "km"
+      "label" = "Km"
+      "type" = "number"
+      "fieldType" = "number"
+    }
+  )
+  "associatedObjects" = @("contact")
+  "requiredProperties" = @("model")
+}
+
+$objectName = $customObject.name
+$objectDetails = $customObject | ConvertTo-Json
+
+$endpoint = "https://api.hubapi.com/crm/v3/schemas"
+
+try {
+  Write-Output "Object to write'$objectDetails'."
+  $response = Invoke-RestMethod -Method Post -Uri $endpoint -Headers @{ Authorization = "Bearer $hubSpotApiKey" } -ContentType "application/json" -Body $objectDetails
+  Write-Output "Object '$objectName' created successfully."
+}catch {
+  $errorMessage = $_.Exception.Response.GetResponseStream()
+  $reader = New-Object System.IO.StreamReader($errorMessage)
+  $reader.BaseStream.Position = 0
+  $reader.DiscardBufferedData()
+  $responseBody = $reader.ReadToEnd()
+  Write-Output "Error creating object '$objectToDelete': $responseBody"
+}

--- a/HubSpot.NET.IntegrationTests/Scripts/DeleteMachineSchema.ps1
+++ b/HubSpot.NET.IntegrationTests/Scripts/DeleteMachineSchema.ps1
@@ -1,0 +1,47 @@
+# Define your HubSpot Private App Key
+$hubSpotApiKey = "your_hubspot_api_key_here"
+
+$objectToDelete = "machine"
+
+# First, list all the objects
+$listEndpoint = "https://api.hubapi.com/crm/v3/objects/$($objectType)"
+try {
+    $listResponse = Invoke-RestMethod -Method Get -Uri $listEndpoint -Headers @{ Authorization = "Bearer $hubSpotApiKey" }
+}
+catch {
+    $listErrorMessage = $_.Exception.Response.GetResponseStream()
+    $listReader = New-Object System.IO.StreamReader($listErrorMessage)
+    $responseBody = $listReader.ReadToEnd()
+    Write-Output "Error listing '$objectType' objects: $responseBody"
+    return
+}
+
+# Then, delete all the objects
+foreach($result in $listResponse.results) {
+    $objectIdToDelete = $result.properties.hs_object_id
+    $deleteEndpoint = "https://api.hubapi.com/crm/v3/objects/$($objectType)/$($objectIdToDelete)"
+
+    try {
+        $deleteResponse = Invoke-RestMethod -Method Delete -Uri $deleteEndpoint -Headers @{ Authorization = "Bearer $hubSpotApiKey" }
+        Write-Output "Object '$objectIdToDelete' deleted successfully."
+    }
+    catch {
+        $errorMessage = $_.Exception.Response.GetResponseStream()
+        $reader = New-Object System.IO.StreamReader($errorMessage)
+        $responseBody = $reader.ReadToEnd()
+        Write-Output "Error deleting object '$objectIdToDelete': $responseBody"
+    }
+}
+
+# Finally, delete the custom object schema
+$deleteSchemaEndpoint = "https://api.hubapi.com/crm/v3/schemas/$($objectType)"
+try {
+    $deleteResponse = Invoke-RestMethod -Method Delete -Uri $deleteSchemaEndpoint -Headers @{ Authorization = "Bearer $hubSpotApiKey" }
+    Write-Output "Schema '$objectType' deleted successfully."
+}
+catch {
+    $errorMessage = $_.Exception.Response.GetResponseStream()
+    $reader = New-Object System.IO.StreamReader($errorMessage)
+    $responseBody = $reader.ReadToEnd()
+    Write-Output "Error deleting schema '$objectType': $responseBody"
+}

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -205,10 +205,30 @@ namespace HubSpot.NET.Api.CustomObject
             return _client.ExecuteAsync<T>(path, Method.GET, convertToPropertiesSchema: false);
         }
 
+        public T GetObject<T>(string schemaId, string objectId, List<string> properties)
+            where T : CustomObjectHubSpotModel, new()
+        {
+            properties ??= new List<string>();
+
+            var path = $"{RouteBasePath}/{schemaId}/{objectId}";
+
+            foreach (var property in properties)
+            {
+                path = path.SetQueryParam("properties", property);
+            }
+            return _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: false);
+        }
+
         public Task DeleteObjectAsync(string objectType, string objectId)
         {
             var path = $"{RouteBasePath}/{objectType}/{objectId}";
             return _client.ExecuteAsync(path, null, Method.DELETE, convertToPropertiesSchema: false);
+        }
+
+        public void DeleteObject(string objectType, string objectId)
+        {
+            var path = $"{RouteBasePath}/{objectType}/{objectId}";
+            _client.Execute(path, null, Method.DELETE, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -37,7 +37,7 @@ namespace HubSpot.NET.Api.CustomObject
                 .SetQueryParam("count", opts.Limit);
 
             if (opts.PropertiesToInclude.Any())
-                path = path.SetQueryParam("property", opts.PropertiesToInclude);
+                path = path.SetQueryParam("properties", opts.PropertiesToInclude);
 
             if (opts.Offset.HasValue)
                 path = path.SetQueryParam("vidOffset", opts.Offset);
@@ -137,7 +137,7 @@ namespace HubSpot.NET.Api.CustomObject
                 .SetQueryParam("count", opts.Limit);
 
             if (opts.PropertiesToInclude.Any())
-                path = path.SetQueryParam("property", opts.PropertiesToInclude);
+                path = path.SetQueryParam("properties", opts.PropertiesToInclude);
 
             if (opts.Offset.HasValue)
                 path = path.SetQueryParam("vidOffset", opts.Offset);

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -193,6 +193,16 @@ namespace HubSpot.NET.Api.CustomObject
             return string.Empty;
         }
 
+        public TReturn CreateObject<TCreate, TReturn>(TCreate entity)
+            where TCreate : CreateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new()
+        {
+            var path = $"{RouteBasePath}/{entity.SchemaId}";
+
+            return _client.Execute<TReturn>(path, entity, Method.POST,
+                convertToPropertiesSchema: false);
+        }
+
         public Task<TReturn> CreateObjectAsync<TCreate, TReturn>(TCreate entity)
             where TCreate : CreateCustomObjectHubSpotModel, new()
             where TReturn : CustomObjectHubSpotModel, new()

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -111,6 +111,18 @@ namespace HubSpot.NET.Api.CustomObject
             return string.Empty;
         }
 
+        public TReturn UpdateObject<TUpdate, TReturn>(TUpdate entity)
+            where TUpdate : UpdateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new()
+        {
+            var path = $"{RouteBasePath}/{entity.SchemaId}/{entity.Id}";
+
+            var updatedObject = _client.Execute<TReturn>(path, entity, Method.PATCH,
+                convertToPropertiesSchema: false);
+
+            return updatedObject;
+        }
+
         public T GetEquipmentDataById<T>(string schemaId, string entityId, string properties = "")
             where T : HubspotEquipmentObjectModel, new()
         {

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -193,14 +193,16 @@ namespace HubSpot.NET.Api.CustomObject
             return string.Empty;
         }
 
-        public async Task<string> UpdateObjectAsync<T>(T entity) where T : UpdateCustomObjectHubSpotModel, new()
+        public async Task<TReturn> UpdateObjectAsync<TUpdate, TReturn>(TUpdate entity)
+            where TUpdate : UpdateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new()
         {
             var path = $"{RouteBasePath}/{entity.SchemaId}/{entity.Id}";
 
-            await _client.ExecuteAsync<UpdateCustomObjectHubSpotModel>(path, entity, Method.PATCH,
+            var updatedObject = await _client.ExecuteAsync<TReturn>(path, entity, Method.PATCH,
                 convertToPropertiesSchema: false);
 
-            return string.Empty;
+            return updatedObject;
         }
 
         public Task<T> GetObjectAsync<T>(string schemaId, string objectId, List<string> properties)

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -190,20 +190,17 @@ namespace HubSpot.NET.Api.CustomObject
             return string.Empty;
         }
 
-        public Task<T> GetEquipmentDataByIdAsync<T>(string schemaId, string entityId, string properties = "")
-            where T : HubspotEquipmentObjectModel, new()
+        public Task<T> GetObjectAsync<T>(string schemaId, string objectId)
+            where T : CustomObjectHubSpotModel, new()
         {
-            if (properties == "")
-            {
-                properties = EquipmentObjectList.GetEquipmentPropsList();
-            }
+            var path = $"{RouteBasePath}/{schemaId}/{objectId}";
+            return _client.ExecuteAsync<T>(path, Method.GET, convertToPropertiesSchema: false);
+        }
 
-            var path = $"{RouteBasePath}/{schemaId}/{entityId}";
-
-            path = path.SetQueryParam("properties",
-                properties); //properties is comma seperated value of properties to include
-
-            return _client.ExecuteAsync<T>(path, Method.GET, convertToPropertiesSchema: true);
+        public Task DeleteObjectAsync(string objectType, string objectId)
+        {
+            var path = $"{RouteBasePath}/{objectType}/{objectId}";
+            return _client.ExecuteAsync(path, null, Method.DELETE, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -190,10 +191,17 @@ namespace HubSpot.NET.Api.CustomObject
             return string.Empty;
         }
 
-        public Task<T> GetObjectAsync<T>(string schemaId, string objectId)
+        public Task<T> GetObjectAsync<T>(string schemaId, string objectId, List<string> properties)
             where T : CustomObjectHubSpotModel, new()
         {
+            properties ??= new List<string>();
+
             var path = $"{RouteBasePath}/{schemaId}/{objectId}";
+
+            foreach (var property in properties)
+            {
+                path = path.SetQueryParam("properties", property);
+            }
             return _client.ExecuteAsync<T>(path, Method.GET, convertToPropertiesSchema: false);
         }
 

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -193,6 +193,16 @@ namespace HubSpot.NET.Api.CustomObject
             return string.Empty;
         }
 
+        public Task<TReturn> CreateObjectAsync<TCreate, TReturn>(TCreate entity)
+            where TCreate : CreateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new()
+        {
+            var path = $"{RouteBasePath}/{entity.SchemaId}";
+
+            return _client.ExecuteAsync<TReturn>(path, entity, Method.POST,
+                    convertToPropertiesSchema: false);
+        }
+
         public async Task<TReturn> UpdateObjectAsync<TUpdate, TReturn>(TUpdate entity)
             where TUpdate : UpdateCustomObjectHubSpotModel, new()
             where TReturn : CustomObjectHubSpotModel, new()

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -30,6 +30,10 @@ namespace HubSpot.NET.Core.Interfaces
             string associateToObjectId)
             where T : CreateCustomObjectHubSpotModel, new();
 
+        TReturn CreateObject<TCreate, TReturn>(TCreate entity)
+            where TCreate : CreateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new();
+
         Task<TReturn> CreateObjectAsync<TCreate, TReturn>(TCreate entity)
             where TCreate : CreateCustomObjectHubSpotModel, new()
             where TReturn : CustomObjectHubSpotModel, new();

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -30,6 +30,10 @@ namespace HubSpot.NET.Core.Interfaces
             string associateToObjectId)
             where T : CreateCustomObjectHubSpotModel, new();
 
+        Task<TReturn> CreateObjectAsync<TCreate, TReturn>(TCreate entity)
+            where TCreate : CreateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new();
+
         string UpdateObject<T>(T entity)
             where T : UpdateCustomObjectHubSpotModel, new();
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -37,8 +37,9 @@ namespace HubSpot.NET.Core.Interfaces
             where TUpdate : UpdateCustomObjectHubSpotModel, new()
             where TReturn : CustomObjectHubSpotModel, new();
 
-        Task<string> UpdateObjectAsync<T>(T entity)
-            where T : UpdateCustomObjectHubSpotModel, new();
+        Task<TReturn> UpdateObjectAsync<TUpdate, TReturn>(TUpdate entity)
+            where TUpdate : UpdateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new();
 
         T GetEquipmentDataById<T>(string schemaId, string entityId, string properties = "")
             where T : HubspotEquipmentObjectModel, new();

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -38,7 +38,7 @@ namespace HubSpot.NET.Core.Interfaces
         T GetEquipmentDataById<T>(string schemaId, string entityId, string properties = "")
             where T : HubspotEquipmentObjectModel, new();
 
-        Task<T> GetEquipmentDataByIdAsync<T>(string schemaId, string entityId, string properties = "")
-            where T : HubspotEquipmentObjectModel, new();
+        Task<T> GetObjectAsync<T>(string schemaId, string objectId)
+            where T : CustomObjectHubSpotModel, new();
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -39,7 +39,14 @@ namespace HubSpot.NET.Core.Interfaces
         T GetEquipmentDataById<T>(string schemaId, string entityId, string properties = "")
             where T : HubspotEquipmentObjectModel, new();
 
+        T GetObject<T>(string schemaId, string objectId, List<string> properties)
+            where T : CustomObjectHubSpotModel, new();
+
         Task<T> GetObjectAsync<T>(string schemaId, string objectId, List<string> properties)
             where T : CustomObjectHubSpotModel, new();
+
+        Task DeleteObjectAsync(string objectType, string objectId);
+
+        void DeleteObject(string objectType, string objectId);
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -33,6 +33,10 @@ namespace HubSpot.NET.Core.Interfaces
         string UpdateObject<T>(T entity)
             where T : UpdateCustomObjectHubSpotModel, new();
 
+        TReturn UpdateObject<TUpdate, TReturn>(TUpdate entity)
+            where TUpdate : UpdateCustomObjectHubSpotModel, new()
+            where TReturn : CustomObjectHubSpotModel, new();
+
         Task<string> UpdateObjectAsync<T>(T entity)
             where T : UpdateCustomObjectHubSpotModel, new();
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using HubSpot.NET.Api.CustomObject;
@@ -38,7 +39,7 @@ namespace HubSpot.NET.Core.Interfaces
         T GetEquipmentDataById<T>(string schemaId, string entityId, string properties = "")
             where T : HubspotEquipmentObjectModel, new();
 
-        Task<T> GetObjectAsync<T>(string schemaId, string objectId)
+        Task<T> GetObjectAsync<T>(string schemaId, string objectId, List<string> properties)
             where T : CustomObjectHubSpotModel, new();
     }
 }


### PR DESCRIPTION
## Description
This PR adds new methods and fixes the existing methods to work with custom objects.

## Purpose
- [x] Custom Objects API methods implemented

## Steps to test
To execute the Custom Object integration tests you need to setup a `Machine` object via a script. See more in the README file of the IntegrationTests project. Then run `HubSpotCompanyApiAsyncIntegrationTests`.

Partially resolves: [PD-9612](https://powerdiary.atlassian.net/browse/PD-9612)


[PD-9612]: https://powerdiary.atlassian.net/browse/PD-9612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ