### PR TITLE
Downgrade RestSharp package version to 110.2.0.

### DIFF
--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="111.4.0" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION

## Description
We have to downgrade the RestSharp version as it is incompatible with the latest Xero library dependency.
RestSharp package downgraded from version 111.4.0 to 110.2.0 to resolve compatibility issues. This change ensures that the project maintains stability and functions as expected with other dependencies.

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added tests to prove that what I have fixed or added does indeed work
- [x] I have added documentation as necessary
