### PR TITLE
Downgrade RestSharp to version 110.2.0

### DIFF
--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Authors>HubSpot.NET;PowerDiary</Authors>
     <Company>PowerDiary</Company>
     <Description>.NET client library targeting the HubSpot APIs.</Description>
@@ -12,7 +12,7 @@
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm custom objects</PackageTags>
     <PackageReleaseNotes>1.0.0</PackageReleaseNotes>
     <PackageId>PowerDiary.HubSpot.NET</PackageId>
-    <PackageVersion>1.0.4</PackageVersion>
+    <PackageVersion>1.0.5</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>8</LangVersion>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>

--- a/HubSpot.NET/HubSpot.NET.nuspec
+++ b/HubSpot.NET/HubSpot.NET.nuspec
@@ -2,8 +2,8 @@
 <package >
   <metadata>
     <id>PowerDiary.HubSpot.NET</id>
-    <version>1.0.4</version>
-    <releaseNotes>Updated the RestSharp package from version 106.12.0 to 111.4.0 to ensure compatibility with the latest version. This involved changing method calls from uppercase HTTP verbs to PascalCase (e.g., Method.GET to Method.Get) and adjusting code to account for other breaking changes in the update. Additionally, removed obsolete FakeSerializer and NewtonsoftRestSharpSerializer classes.</releaseNotes>
+    <version>1.0.5</version>
+    <releaseNotes>Downgraded the RestSharp package to version 110.2.0 to make it compatible with other projects in PowerDiary.</releaseNotes>
     <title>PowerDiary's Fork of HubSpot.NET</title>
     <authors>PowerDiary</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
## Description
Updated the RestSharp package from version 111.4.0 to 110.2.0 to ensure compatibility with other projects in PowerDiary. This update also increments the package version to 1.0.5.

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added tests to prove that what I have fixed or added does indeed work
- [x] I have added documentation as necessary
