### PR TITLE
PD-9613 Increases the version number of the NuGet package to publish the LineItem API

### DIFF
--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <Authors>HubSpot.NET;PowerDiary</Authors>
     <Company>PowerDiary</Company>
     <Description>.NET client library targeting the HubSpot APIs.</Description>
@@ -10,9 +10,9 @@
     <PackageProjectUrl>https://github.com/powerdiary/HubSpot.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/powerdiary/HubSpot.NET.git</RepositoryUrl>
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm custom objects</PackageTags>
-    <PackageReleaseNotes>1.0.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Added `HubSpotLineItemApi` with separate models for requests and responses due to differences in Deal associations.</PackageReleaseNotes>
     <PackageId>PowerDiary.HubSpot.NET</PackageId>
-    <PackageVersion>1.0.5</PackageVersion>
+    <PackageVersion>1.0.6</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>8</LangVersion>
     <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>

--- a/HubSpot.NET/HubSpot.NET.nuspec
+++ b/HubSpot.NET/HubSpot.NET.nuspec
@@ -2,8 +2,8 @@
 <package >
   <metadata>
     <id>PowerDiary.HubSpot.NET</id>
-    <version>1.0.5</version>
-    <releaseNotes>Downgraded the RestSharp package to version 110.2.0 to make it compatible with other projects in PowerDiary.</releaseNotes>
+    <version>1.0.6</version>
+    <releaseNotes>Added the `HubSpotLineItemApi` with separate models for request and response due to differences in Deal associations.</releaseNotes>
     <title>PowerDiary's Fork of HubSpot.NET</title>
     <authors>PowerDiary</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
## Description
This PR increases the version number of the NuGet package to publish the LineItem API.

Partially addresses [PD-9613](https://powerdiary.atlassian.net/browse/PD-9613)

[PD-9613]: https://powerdiary.atlassian.net/browse/PD-9613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ