### PR TITLE
Add support for custom event completion using Api

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         [Fact]
         public async Task SendEventTrackingDataForContact_WhenValidData_ShouldSucceedWithNoException()
         {            
-            var eventDefinition = await GetOrCreateTestEventDefinition();
+            var eventDefinition = await GetTestEventDefinition();
             var contact = await RecreateTestContactAsync();
 
             var eventTracking = CreateTestEventTracking(contact.Email, eventDefinition.FullyQualifiedName);
@@ -36,7 +36,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         [Fact]
         public async Task SendEventTrackingDataForContact_WhenInvalidEmail_ShouldNotThrowException()
         {
-            var eventDefinition = await GetOrCreateTestEventDefinition();
+            var eventDefinition = await GetTestEventDefinition();
 
             var eventTracking = CreateTestEventTracking("invalid_email", eventDefinition.FullyQualifiedName);
 
@@ -64,7 +64,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task SendEventTrackingDataForCompany_WhenValidData_ShouldSucceedWithNoException()
         {
             var company = await RecreateTestCompanyAsync();
-            var eventDefinition = await GetOrCreateTestEventDefinition("test_event2", "COMPANY");
+            var eventDefinition = await GetTestEventDefinition("test_event2", "COMPANY");
             var eventTracking = CreateTestEventTracking(company.Id.Value, eventDefinition.FullyQualifiedName);
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
@@ -76,7 +76,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task SendEventTrackingDataForCompany_WhenInvalidObjectId_ShouldNotThrowException()
         {
             long randomNonExistingCompanyId = 10000234;
-            var eventDefinition = await GetOrCreateTestEventDefinition("test_event2", "COMPANY");
+            var eventDefinition = await GetTestEventDefinition("test_event2", "COMPANY");
             var eventTracking = CreateTestEventTracking(randomNonExistingCompanyId, eventDefinition.FullyQualifiedName);
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -1,0 +1,107 @@
+﻿using FluentAssertions;
+using HubSpot.NET.Api.CustomEvent.Dto;
+using HubSpot.NET.Api.Schemas;
+using HubSpot.NET.Core;
+
+namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
+{
+    public class HubSpotCustomEventApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
+    {
+        private const string EventName = "test_event1";
+
+        [Fact]
+        public async Task SendEventTrackingDataForContact_WhenValidData_ShouldSucceedWithNoException()
+        {            
+            var eventDefinition = await GetOrCreateTestEventDefinition();
+            var contact = await RecreateTestContactAsync();
+
+            var eventTracking = CreateTestEventTracking(contact.Email, eventDefinition.FullyQualifiedName);
+
+            Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
+
+            await act.Should().NotThrowAsync();            
+        }
+
+        [Fact]
+        public async Task SendEventTrackingDataForContact_WhenInvalidEvent_ShouldThrowException()
+        {
+            var contact = await RecreateTestContactAsync();
+            var eventTracking = CreateTestEventTracking(contact.Email, "nonexisting_event");
+
+            Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
+
+            await act.Should().ThrowAsync<HubSpotException>();
+        }
+
+        [Fact]
+        public async Task SendEventTrackingDataForContact_WhenInvalidEmail_ShouldNotThrowException()
+        {
+            var eventDefinition = await GetOrCreateTestEventDefinition();
+
+            var eventTracking = CreateTestEventTracking("invalid_email", eventDefinition.FullyQualifiedName);
+
+            Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
+
+            await act.Should().NotThrowAsync();
+        }        
+
+        [Fact]
+        public async Task GetByNameAsync_WhenValidEventName_ShouldReturnEvent()
+        {
+            var result = await CustomEventApi.GetByNameAsync<EventDefinition>(EventName);
+
+            result.Should().BeEquivalentTo(new EventDefinition
+            {
+                Name = EventName,
+                Label = new SchemasLabelsModel() { Singular = "Test Event1" }
+            }, options =>
+            options
+                .Excluding(e => e.Description)
+                .Excluding(e => e.FullyQualifiedName));
+        }
+
+        [Fact]
+        public async Task SendEventTrackingDataForCompany_WhenValidData_ShouldSucceedWithNoException()
+        {
+            var company = await RecreateTestCompanyAsync();
+            var eventDefinition = await GetOrCreateTestEventDefinition("test_event2", "COMPANY");
+            var eventTracking = CreateTestEventTracking(company.Id.Value, eventDefinition.FullyQualifiedName);
+
+            Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task SendEventTrackingDataForCompany_WhenInvalidObjectId_ShouldNotThrowException()
+        {
+            long randomNonExistingCompanyId = 10000234;
+            var eventDefinition = await GetOrCreateTestEventDefinition("test_event2", "COMPANY");
+            var eventTracking = CreateTestEventTracking(randomNonExistingCompanyId, eventDefinition.FullyQualifiedName);
+
+            Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
+
+            await act.Should().NotThrowAsync();
+        }
+
+        private EventTracking CreateTestEventTracking(string email, string eventName)
+        {            
+            return new EventTracking
+            {
+                EventName = eventName,
+                OccurredAt = DateTime.UtcNow.ToString("o"),
+                Email = email
+            };
+        }
+
+        private EventTracking CreateTestEventTracking(long id, string eventName)
+        {
+            return new EventTracking
+            {
+                EventName = eventName,
+                OccurredAt = DateTime.UtcNow.ToString("o"),
+                ObjectId = id.ToString()
+            };
+        }
+    }
+}

--- a/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
@@ -215,7 +215,6 @@ public abstract class HubSpotAsyncIntegrationTestBase : HubSpotIntegrationTestSe
         };
 
         var createdEventDefinition = await CustomEventApi.CreateAsync(newEventDefinition);
-        EventDefinitionsToCleanup.Add(createdEventDefinition.Name);
 
         return createdEventDefinition;
     }

--- a/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
@@ -196,7 +196,7 @@ public abstract class HubSpotAsyncIntegrationTestBase : HubSpotIntegrationTestSe
         return (newLineItem, itemGetResponse);
     }
 
-    protected async Task<EventDefinition> GetOrCreateTestEventDefinition(string eventName = "test_event1",
+    protected async Task<EventDefinition> GetTestEventDefinition(string eventName = "test_event1",
         string primaryObject = "CONTACT")
     {
         var existingEventDef = await CustomEventApi.GetByNameAsync<EventDefinition>(eventName);
@@ -206,16 +206,6 @@ public abstract class HubSpotAsyncIntegrationTestBase : HubSpotIntegrationTestSe
             return existingEventDef;
         }
 
-        var newEventDefinition = new EventDefinition
-        {
-            Label = new SchemasLabelsModel() { Singular = eventName, Plural = "Test Events" },
-            Name = "testevent12345",
-            PrimaryObject = primaryObject,
-            Description = "test description"           
-        };
-
-        var createdEventDefinition = await CustomEventApi.CreateAsync(newEventDefinition);
-
-        return createdEventDefinition;
+        throw new KeyNotFoundException($"Event definition with name '{eventName}' was not found.");
     }
 }

--- a/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
@@ -2,9 +2,11 @@
 using HubSpot.NET.Api.Company.Dto;
 using HubSpot.NET.Api.Contact.Dto;
 using HubSpot.NET.Api.ContactList.Dto;
+using HubSpot.NET.Api.CustomEvent.Dto;
 using HubSpot.NET.Api.Deal.Dto;
 using HubSpot.NET.Api.LineItem.DTO;
 using HubSpot.NET.Api.Properties.Dto;
+using HubSpot.NET.Api.Schemas;
 using HubSpot.NET.Core;
 using SearchRequestFilter = HubSpot.NET.Api.SearchRequestFilter;
 using SearchRequestFilterGroup = HubSpot.NET.Api.SearchRequestFilterGroup;
@@ -192,5 +194,29 @@ public abstract class HubSpotAsyncIntegrationTestBase : HubSpotIntegrationTestSe
 
         LineItemsToCleanup.Add(itemGetResponse.Id.Value);
         return (newLineItem, itemGetResponse);
+    }
+
+    protected async Task<EventDefinition> GetOrCreateTestEventDefinition(string eventName = "test_event1",
+        string primaryObject = "CONTACT")
+    {
+        var existingEventDef = await CustomEventApi.GetByNameAsync<EventDefinition>(eventName);
+
+        if (existingEventDef != null)
+        {
+            return existingEventDef;
+        }
+
+        var newEventDefinition = new EventDefinition
+        {
+            Label = new SchemasLabelsModel() { Singular = eventName, Plural = "Test Events" },
+            Name = "testevent12345",
+            PrimaryObject = primaryObject,
+            Description = "test description"           
+        };
+
+        var createdEventDefinition = await CustomEventApi.CreateAsync(newEventDefinition);
+        EventDefinitionsToCleanup.Add(createdEventDefinition.Name);
+
+        return createdEventDefinition;
     }
 }

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestSetup.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestSetup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace HubSpot.NET.IntegrationTests;
 
+using HubSpot.NET.Api.CustomEvent;
 using Xunit;
 
 public abstract class HubSpotIntegrationTestSetup : IAsyncLifetime
@@ -23,6 +24,7 @@ public abstract class HubSpotIntegrationTestSetup : IAsyncLifetime
     protected readonly HubSpotCustomObjectApi CustomObjectApi;
     protected readonly HubSpotDealApi DealApi;
     protected readonly HubSpotLineItemApi LineItemApi;
+    protected readonly HubSpotCustomEventApi CustomEventApi;
 
     protected readonly HubSpotApi HubSpotApi;
 
@@ -55,6 +57,7 @@ public abstract class HubSpotIntegrationTestSetup : IAsyncLifetime
         DealApi = new HubSpotDealApi(client);
         LineItemApi = new HubSpotLineItemApi(client);
         HubSpotApi = new HubSpotApi(apiKey);
+        CustomEventApi = new HubSpotCustomEventApi(client);
     }
 
     public async Task InitializeAsync()

--- a/HubSpot.NET/Api/CustomEvent/Dto/EventDefinition.cs
+++ b/HubSpot.NET/Api/CustomEvent/Dto/EventDefinition.cs
@@ -1,0 +1,39 @@
+﻿using HubSpot.NET.Api.Schemas;
+using HubSpot.NET.Core.Interfaces;
+using System.Runtime.Serialization;
+
+namespace HubSpot.NET.Api.CustomEvent.Dto
+{
+    [DataContract]
+    public class EventDefinition : IHubSpotModel
+    {
+        [DataMember(Name = "labels")]
+        public SchemasLabelsModel Label { get; set; }
+        
+        [DataMember(Name="name")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "description")]
+        public string Description { get; set; }
+
+        [DataMember(Name = "primaryObject")]
+        public string PrimaryObject { get; set; }
+
+        [DataMember(Name = "fullyQualifiedName")]
+        public string FullyQualifiedName { get; set; }
+
+        public bool IsNameValue => true;
+
+        public string RouteBasePath => "/events/v3/event-definitions";
+       
+        public void FromHubSpotDataEntity(dynamic hubspotData)
+        {
+            
+        }
+
+        public void ToHubSpotDataEntity(ref dynamic dataEntity)
+        {
+            
+        }
+    }    
+}

--- a/HubSpot.NET/Api/CustomEvent/Dto/EventTracking.cs
+++ b/HubSpot.NET/Api/CustomEvent/Dto/EventTracking.cs
@@ -1,0 +1,10 @@
+﻿namespace HubSpot.NET.Api.CustomEvent.Dto
+{
+    public class EventTracking
+    {
+        public string EventName { get; set; }
+        public string ObjectId { get; set; }
+        public string OccurredAt { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
@@ -21,12 +21,7 @@ namespace HubSpot.NET.Api.CustomEvent
             var path = "events/v3/send";
             return _client.ExecuteAsync(path, eventTracking, Method.Post, convertToPropertiesSchema: false);
         }
-
-        public Task<T> CreateAsync<T> (T entity) where T : EventDefinition, new()
-        {
-            var path = entity.RouteBasePath;
-            return _client.ExecuteAsync<T>(path, entity, Method.Post, convertToPropertiesSchema: false);
-        }
+        
 
         public Task<T> GetByNameAsync<T>(string eventName) where T : EventDefinition, new()
         {

--- a/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
@@ -1,0 +1,46 @@
+﻿using HubSpot.NET.Api.CustomEvent.Dto;
+using HubSpot.NET.Core;
+using HubSpot.NET.Core.Interfaces;
+using RestSharp;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace HubSpot.NET.Api.CustomEvent
+{
+    public class HubSpotCustomEventApi : IHubSpotCustomEventApi
+    {
+        private readonly IHubSpotClient _client;
+
+        public HubSpotCustomEventApi(IHubSpotClient  client)
+        {
+            _client = client;
+        }
+
+        public Task SendEventTrackingData(EventTracking eventTracking)
+        {
+            var path = "events/v3/send";
+            return _client.ExecuteAsync(path, eventTracking, Method.Post, convertToPropertiesSchema: false);
+        }
+
+        public Task<T> CreateAsync<T> (T entity) where T : EventDefinition, new()
+        {
+            var path = entity.RouteBasePath;
+            return _client.ExecuteAsync<T>(path, entity, Method.Post, convertToPropertiesSchema: false);
+        }
+
+        public Task<T> GetByNameAsync<T>(string eventName) where T : EventDefinition, new()
+        {
+            var path = $"{new T().RouteBasePath}/{eventName}";
+            try
+            {
+                return _client.ExecuteAsync<T>(path, Method.Get, convertToPropertiesSchema: false);
+            }
+            catch (HubSpotException exception)
+            {
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return Task.FromResult<T>(null);
+                throw;
+            }
+        }
+    }
+}

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
@@ -1,0 +1,14 @@
+﻿using HubSpot.NET.Api.CustomEvent.Dto;
+using System.Threading.Tasks;
+
+namespace HubSpot.NET.Core.Interfaces
+{
+    public interface IHubSpotCustomEventApi
+    {
+        Task SendEventTrackingData(EventTracking eventTracking);
+
+        Task<T> CreateAsync<T>(T entity) where T : EventDefinition, new();
+
+        Task<T> GetByNameAsync<T>(string eventName) where T : EventDefinition, new();
+    }
+}

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
@@ -5,9 +5,7 @@ namespace HubSpot.NET.Core.Interfaces
 {
     public interface IHubSpotCustomEventApi
     {
-        Task SendEventTrackingData(EventTracking eventTracking);
-
-        Task<T> CreateAsync<T>(T entity) where T : EventDefinition, new();
+        Task SendEventTrackingData(EventTracking eventTracking);        
 
         Task<T> GetByNameAsync<T>(string eventName) where T : EventDefinition, new();
     }


### PR DESCRIPTION
## Description
This PR adds new methods to sync custom event completion

## Purpose
- [x] New feature (non-breaking change which adds functionality)

## Steps to test
- Run `HubSpotCustomEventApiAsyncIntegrationTests`
- Go to `Data Management > Custom Events` in `Hubspot Initial Integration Sandbox` account. 
- Click on `Test Event1` or `Test Event 2`. On the `Overview` tab, recent activity for event completion should be displayed after running integration tests.

![image](https://github.com/user-attachments/assets/50d05b77-65ab-4dd8-b7e1-f11532c4d36c)

## Checklist

- [x] I have added tests to prove that what I have fixed or added does indeed work

