### PR TITLE
Add SearchAsync endpoint on HubSpotLineItemApi

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/LineItem/HubSpotLineItemApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/LineItem/HubSpotLineItemApiAsyncIntegrationTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Execution;
+using HubSpot.NET.Api;
 using HubSpot.NET.Api.LineItem;
 using HubSpot.NET.Api.LineItem.DTO;
 using HubSpot.NET.Core;
@@ -119,6 +120,45 @@ public sealed class HubSpotLineItemApiAsyncIntegrationTests : HubSpotAsyncIntegr
                 lineItemToValidate.Properties.Name.Should().Be(responseLineItem.Properties.Name);
                 lineItemToValidate.Properties.Price.Should().Be(responseLineItem.Properties.Price);
             }
+        }
+    }
+
+    [Fact]
+    public async Task SearchLineItems()
+    {
+        var uniqueName1 = Guid.NewGuid().ToString("N");
+        var lineItemName = $"Test Line Item {uniqueName1}";
+        var createdLineItem = await CreateTestLineItem(lineItemName);
+
+        await Task.Delay(10000);
+
+        var filterGroup = new SearchRequestFilterGroup { Filters = new List<SearchRequestFilter>() };
+        filterGroup.Filters.Add(new SearchRequestFilter
+        {
+            PropertyName = "name",
+            Operator = SearchRequestFilterOperatorType.EqualTo,
+            Value = lineItemName
+        });
+
+        var searchOptions = new SearchRequestOptions
+        {
+            FilterGroups = new List<SearchRequestFilterGroup>(),
+            PropertiesToInclude = new List<string>
+            {
+                "price", "name"
+            }
+        };
+
+        searchOptions.FilterGroups.Add(filterGroup);
+
+        var searchResults = await LineItemApi.SearchAsync<LineItemGetResponse>(searchOptions);
+
+        using (new AssertionScope())
+        {
+            var foundLineItem= searchResults.Results.FirstOrDefault(c => c.Id == createdLineItem.Item2.Id);
+            foundLineItem.Should().NotBeNull();
+            foundLineItem?.Properties.Name.Should().Be(createdLineItem.Item2.Properties.Name);
+            foundLineItem?.Properties.Price.Should().Be(createdLineItem.Item2.Properties.Price);
         }
     }
 

--- a/HubSpot.NET/Api/LineItem/HubSpotLineItemApi.cs
+++ b/HubSpot.NET/Api/LineItem/HubSpotLineItemApi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using HubSpot.NET.Api.LineItem.DTO;
@@ -103,6 +102,22 @@ namespace HubSpot.NET.Api.LineItem
                     path = path.SetQueryParam("after", opts.Offset);
 
                 return _client.ExecuteListAsync<LineItemListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
+            }
+
+            /// <summary>
+            /// Gets a list of line items based on a search criteria
+            /// </summary>
+            /// <typeparam name="T">Implementation of <see cref="LineItemGetResponse"/></typeparam>
+            /// <param name="opts">Options (limit, offset) and search criteria relating to request</param>
+            /// <returns>List of line items</returns>
+            public Task<SearchHubSpotModel<T>> SearchAsync<T>(SearchRequestOptions opts = null) where T : LineItemGetResponse, new()
+            {
+                if (opts == null)
+                    opts = new SearchRequestOptions();
+
+                var path = "/crm/v3/objects/line_items/search";
+
+                return _client.ExecuteListAsync<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: false);
             }
         }
     }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotLineItemApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotLineItemApi.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using HubSpot.NET.Api;
 using HubSpot.NET.Api.LineItem;
 using HubSpot.NET.Api.LineItem.DTO;
 
@@ -19,6 +20,9 @@ namespace HubSpot.NET.Core.Interfaces
             where TResponse : LineItemGetResponse, new();
 
         Task<LineItemListHubSpotModel<T>> ListAsync<T>(LineItemListRequestOptions opts = null)
+            where T : LineItemGetResponse, new();
+
+        Task<SearchHubSpotModel<T>> SearchAsync<T>(SearchRequestOptions opts = null)
             where T : LineItemGetResponse, new();
     }
 }


### PR DESCRIPTION
## Description
This PR adds new `SearchAsync` method to the `HubSpotLineItemApi` to search line items. 

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Steps to test

- Run `HubSpotLineItemApiAsyncIntegrationTests`.
- Verify that it passes.

## Checklist

- [x] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
