### PR TITLE
Add GetAssociationsAsync endpoint in HubSpotAssociationsApi

### DIFF
--- a/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiAsyncIntegrationTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using FluentAssertions.Execution;
+using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Api.Contact.Dto;
 
 namespace HubSpot.NET.IntegrationTests.Api.Associations;
@@ -58,6 +59,36 @@ public sealed class HubSpotAssociationsApiAsyncIntegrationTests : HubSpotAsyncIn
         {
             fetchedContact.AssociatedCompanyId.Should().Be(expectedCompany.Id.Value,
                 "The associated company ID should be present in the retrieved contact");
+        }
+    }
+
+    [Fact]
+    public async Task GetAssociationsAsync_GivenSourceIdTypeAndTargetType_ShouldReturnAssociations()
+    {
+        var expectedCompany = await RecreateTestCompanyAsync();
+        var expectedContact = await RecreateTestContactAsync();
+
+        var expectedObjectType = "Company";
+        var expectedObjectId = expectedCompany.Id.Value.ToString();
+        var expectedToObjectType = "Contact";
+        var expectedToObjectId = expectedContact.Id.Value.ToString();
+
+        await AssociationsApi.AssociationToObjectAsync(expectedObjectType, expectedObjectId, expectedToObjectType,
+            expectedToObjectId);
+
+        // Need to wait for data to be searchable.
+        await Task.Delay(10000);
+
+        var fromObjectType = expectedObjectType;
+        var fromObjectId = expectedObjectId;
+        var toObjectType = expectedToObjectType;
+        var associationListHubSpotModel = await AssociationsApi.GetAssociationsAsync<AssociationListHubSpotModel>(fromObjectType, fromObjectId, toObjectType);
+
+        using (new AssertionScope())
+        {
+            associationListHubSpotModel.Should().NotBeNull();
+            associationListHubSpotModel.Associations.Should().HaveCountGreaterThan(0);
+            associationListHubSpotModel.Associations[0].AssociatedObjectId.Should().Be(expectedContact.Id.Value);
         }
     }
 }

--- a/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
@@ -1,0 +1,40 @@
+﻿using HubSpot.NET.Core.Interfaces;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace HubSpot.NET.Api.Associations.Dto
+{
+    /// <summary>
+    /// Models the associations of a HubSpot Object to other HubSpot Objects
+    /// </summary>
+    [DataContract]
+    public class AssociationListHubSpotModel : IHubSpotModel
+    {
+        [JsonProperty(PropertyName = "results")]
+        public List<Association> Associations { get; set; } = new List<Association>();
+
+        public class Association
+        {
+            [JsonProperty(PropertyName = "toObjectId")]
+            public long AssociatedObjectId { get; set; }
+            public List<AssociationType> AssociationTypes { get; set; } = new List<AssociationType>();
+        }
+
+        public class AssociationType
+        {
+            public string Category { get; set; } // HUBSPOT_DEFINED or USER_DEFINED
+            public long TypeId { get; set; }
+            public string Label { get; set; } // e.g. "Contact with Primary Company"
+        }
+
+
+        public bool IsNameValue => false;
+
+        public void ToHubSpotDataEntity(ref dynamic dataEntity) { }
+
+        public void FromHubSpotDataEntity(dynamic hubspotData) { }
+
+        public string RouteBasePath => "/crm/v4/objects/";
+    }
+}

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Core.Interfaces;
 using RestSharp;
 
@@ -73,6 +74,20 @@ namespace HubSpot.NET.Api.Associations
             };
             var body = new[] { label };
             return _client.ExecuteAsync(associationPath, body, Method.Put, convertToPropertiesSchema: false);
+        }
+
+        /// <summary>
+        /// Retrieves alls associations of a given object to the specified object type
+        /// </summary>
+        /// <param name="objectType">Object type id of the object whose associations you're retrieving (e.g. "0-2" for company)</param>
+        /// <param name="objectId">Object id of the object whose associations you're retrieving</param>
+        /// <param name="toObjectType">Object type id of the associations to retrieve (e.g. "0-1" for contact)</param>
+        /// <returns></returns>
+        public Task<T> GetAssociationsAsync<T>(string objectType, string objectId, string toObjectType) where T : AssociationListHubSpotModel, new()
+        {
+            var associationPath = $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";            
+
+            return _client.ExecuteListAsync<T>(associationPath, Method.Get, convertToPropertiesSchema: false); ;
         }
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -1,3 +1,4 @@
+using HubSpot.NET.Api.Associations.Dto;
 using System.Threading.Tasks;
 
 namespace HubSpot.NET.Core.Interfaces
@@ -13,5 +14,7 @@ namespace HubSpot.NET.Core.Interfaces
 
         Task AssociationToObjectByLabelAsync(string objectType, string objectId, string toObjectType, string toObjectId,
             string associationCategory, int associationTypeId);
+
+        Task<T> GetAssociationsAsync<T>(string objectType, string objectId, string toObjectType) where T : AssociationListHubSpotModel, new();
     }
 }


### PR DESCRIPTION
## Description

This PR adds new `GetAssociationsAsync` method to the `HubSpotAssociationsApi` to retrieve associated records.

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Steps to test
- Run `HubSpotAssociationsApiAsyncIntegrationTests`.
- Verify that it passes.

## Checklist

- [x] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
