### PR TITLE
PD-12846 Migrate from object type literals to IDs

### DIFF
--- a/HubSpot.NET.Examples/DemonstrateAPI.cs
+++ b/HubSpot.NET.Examples/DemonstrateAPI.cs
@@ -45,9 +45,9 @@ namespace HubSpot.NET.Examples
 
                 // Associate the contact with the company
                 _api.Associations.AssociationToObject(
-                    HubSpot.NET.Core.HubSpotObjectIds.Contact,
+                    HubSpotObjectTypes.CONTACT,
                     createdContact.Id.Value.ToString(),
-                    HubSpot.NET.Core.HubSpotObjectIds.Company,
+                    HubSpotObjectTypes.COMPANY,
                     createdCompany.Id.Value.ToString());
 
                 Console.WriteLine($"Contact {createdContact.Id} is now associated with company {createdCompany.Id}");

--- a/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Associations/HubSpotAssociationsApiAsyncIntegrationTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions.Execution;
 using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Api.Contact.Dto;
+using HubSpot.NET.Core;
 
 namespace HubSpot.NET.IntegrationTests.Api.Associations;
 
@@ -13,9 +14,9 @@ public sealed class HubSpotAssociationsApiAsyncIntegrationTests : HubSpotAsyncIn
         var expectedCompany = await RecreateTestCompanyAsync();
         var expectedContact = await RecreateTestContactAsync();
 
-        var expectedObjectType = "Company";
+        var expectedObjectType = HubSpotObjectTypes.COMPANY;
         var expectedObjectId = expectedCompany.Id.Value.ToString();
-        var expectedToObjectType = "Contact";
+        var expectedToObjectType = HubSpotObjectTypes.CONTACT;
         var expectedToObjectId = expectedContact.Id.Value.ToString();
 
         await AssociationsApi.AssociationToObjectAsync(expectedObjectType, expectedObjectId, expectedToObjectType,
@@ -39,9 +40,9 @@ public sealed class HubSpotAssociationsApiAsyncIntegrationTests : HubSpotAsyncIn
         var expectedCompany = await RecreateTestCompanyAsync();
         var expectedContact = await RecreateTestContactAsync();
 
-        var expectedObjectType = "Company";
+        var expectedObjectType = HubSpotObjectTypes.COMPANY;
         var expectedObjectId = expectedCompany.Id.Value.ToString();
-        var expectedToObjectType = "Contact";
+        var expectedToObjectType = HubSpotObjectTypes.CONTACT;
         var expectedToObjectId = expectedContact.Id.Value.ToString();
         var expectedAssociationCategory = "YOUR_ASSOCIATION_CATEGORY";
         var expectedAssociationTypeId = 0; // replace with your actual association type ID
@@ -68,9 +69,9 @@ public sealed class HubSpotAssociationsApiAsyncIntegrationTests : HubSpotAsyncIn
         var expectedCompany = await RecreateTestCompanyAsync();
         var expectedContact = await RecreateTestContactAsync();
 
-        var expectedObjectType = "Company";
+        var expectedObjectType = HubSpotObjectTypes.COMPANY;
         var expectedObjectId = expectedCompany.Id.Value.ToString();
-        var expectedToObjectType = "Contact";
+        var expectedToObjectType = HubSpotObjectTypes.CONTACT;
         var expectedToObjectId = expectedContact.Id.Value.ToString();
 
         await AssociationsApi.AssociationToObjectAsync(expectedObjectType, expectedObjectId, expectedToObjectType,

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Execution;
 using HubSpot.NET.Api.CustomEvent.Dto;
 using HubSpot.NET.Api.Schemas;
 using HubSpot.NET.Core;
+using System.Net;
 
 namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 {
@@ -67,19 +68,21 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
             CustomEventsToCleanup.Remove(eventDefinition.Name);
 
             // Assert
-            var deletedEvent = await CustomEventApi.GetByNameAsync<EventDefinition>(eventDefinition.Name);
-            deletedEvent.Should().BeNull();
+            Func<Task> act = async () => await CustomEventApi.GetByNameAsync<EventDefinition>(eventDefinition.Name);
+            await act.Should().ThrowAsync<HubSpotException>()
+                .Where(e => e.ReturnedError.StatusCode == HttpStatusCode.BadRequest);
         }
 
         [Fact]
-        public async Task DeleteEventDefinitionAsync_WhenNonExistentEvent_ShouldNotThrowException()
+        public async Task DeleteEventDefinitionAsync_WhenNonExistentEvent_ShouldThrowException()
         {
             // Arrange
             var nonExistentEventName = "test_event_" + Guid.NewGuid().ToString("N");
 
             // Act & Assert
-            await CustomEventApi.DeleteEventDefinitionAsync(nonExistentEventName);
-            // Should not throw an exception
+            Func<Task> act = async () => await CustomEventApi.DeleteEventDefinitionAsync(nonExistentEventName);
+            await act.Should().ThrowAsync<HubSpotException>()
+                .Where(e => e.ReturnedError.StatusCode == HttpStatusCode.BadRequest);
         }
 
         [Fact]

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -41,6 +41,42 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         }
 
         [Fact]
+        public async Task DeleteEventDefinitionAsync_WhenValidEvent_ShouldDeleteEvent()
+        {
+            // Arrange
+            var eventDefinition = new EventDefinition
+            {
+                Name = "test_event_" + Guid.NewGuid().ToString("N"),
+                Label = "Test Event",
+                Labels = new SchemasLabelsModel { Singular = "Test Event" },
+                Description = "Test event description",
+                PrimaryObjectId = "0-1",
+                TrackingType = "MANUAL"
+            };
+
+            var createdEvent = await CustomEventApi.CreateEventDefinitionAsync(eventDefinition);
+            createdEvent.Should().NotBeNull();
+
+            // Act
+            await CustomEventApi.DeleteEventDefinitionAsync(createdEvent.Name);
+
+            // Assert
+            var deletedEvent = await CustomEventApi.GetByNameAsync<EventDefinition>(createdEvent.Name);
+            deletedEvent.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task DeleteEventDefinitionAsync_WhenNonExistentEvent_ShouldNotThrowException()
+        {
+            // Arrange
+            var nonExistentEventName = "test_event_" + Guid.NewGuid().ToString("N");
+
+            // Act & Assert
+            await CustomEventApi.DeleteEventDefinitionAsync(nonExistentEventName);
+            // Should not throw an exception
+        }
+
+        [Fact]
         public async Task SendEventTrackingDataForContact_WhenValidData_ShouldSucceedWithNoException()
         {            
             var eventDefinition = await GetTestEventDefinition();

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -8,7 +8,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 {
     public class HubSpotCustomEventApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
     {
-        private const string EventName = "test_event1";
+        private const string EventName = "test_event_7f91f99b415f4643be52638bad48699f";
 
         [Fact]
         public async Task CreateEventDefinitionAsync_WhenValidEvent_ShouldCreateEvent()
@@ -120,7 +120,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
             result.Should().BeEquivalentTo(new EventDefinition
             {
                 Name = EventName,
-                Labels = new SchemasLabelsModel() { Singular = "Test Event1" }
+                Labels = new SchemasLabelsModel() { Singular = "Test Event" }
             }, options =>
             options
                 .Excluding(e => e.Description)

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using FluentAssertions.Execution;
 using HubSpot.NET.Api.CustomEvent.Dto;
 using HubSpot.NET.Api.Schemas;
 using HubSpot.NET.Core;
@@ -8,6 +9,36 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
     public class HubSpotCustomEventApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
     {
         private const string EventName = "test_event1";
+
+        [Fact]
+        public async Task CreateEventDefinitionAsync_WhenValidEvent_ShouldCreateEvent()
+        {
+            // Arrange
+            var eventDefinition = new EventDefinition
+            {
+                Name = "test_event_" + Guid.NewGuid().ToString("N"),
+                Label = "Test Event",
+                Labels = new SchemasLabelsModel { Singular = "Test Event" },
+                Description = "Test event description",
+                PrimaryObjectId = "0-1", // 0-1 is the ID for CONTACT
+                TrackingType = "MANUAL"
+            };
+
+            // Act
+            var result = await CustomEventApi.CreateEventDefinitionAsync(eventDefinition);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().NotBeNull();
+                result.Name.Should().Be(eventDefinition.Name);
+                result.Labels.Singular.Should().Be(eventDefinition.Labels.Singular);
+                result.Description.Should().Be(eventDefinition.Description);
+                result.PrimaryObjectId.Should().Be(eventDefinition.PrimaryObjectId);
+                result.TrackingType.Should().Be(eventDefinition.TrackingType);
+                result.Archived.Should().BeFalse();
+            }
+        }
 
         [Fact]
         public async Task SendEventTrackingDataForContact_WhenValidData_ShouldSucceedWithNoException()
@@ -53,11 +84,17 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
             result.Should().BeEquivalentTo(new EventDefinition
             {
                 Name = EventName,
-                Label = new SchemasLabelsModel() { Singular = "Test Event1" }
+                Labels = new SchemasLabelsModel() { Singular = "Test Event1" }
             }, options =>
             options
                 .Excluding(e => e.Description)
-                .Excluding(e => e.FullyQualifiedName));
+                .Excluding(e => e.FullyQualifiedName)
+                .Excluding(e => e.Id)
+                .Excluding(e => e.CreatedAt)
+                .Excluding(e => e.UpdatedAt)
+                .Excluding(e => e.Archived)
+                .Excluding(e => e.TrackingType)
+                .Excluding(e => e.PrimaryObjectId));
         }
 
         [Fact]

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -8,7 +8,22 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 {
     public class HubSpotCustomEventApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
     {
-        private const string EventName = "test_event_7f91f99b415f4643be52638bad48699f";
+        private async Task<EventDefinition> CreateUniqueEventDefinitionAsync(string primaryObjectId = "0-1")
+        {
+            var eventDefinition = new EventDefinition
+            {
+                Name = "test_event_" + Guid.NewGuid().ToString("N"),
+                Label = "Test Event",
+                Labels = new SchemasLabelsModel { Singular = "Test Event" },
+                Description = "Test event description",
+                PrimaryObjectId = primaryObjectId,
+                TrackingType = "MANUAL"
+            };
+
+            var createdEvent = await CustomEventApi.CreateEventDefinitionAsync(eventDefinition);
+            CustomEventsToCleanup.Add(createdEvent.Name);
+            return createdEvent;
+        }
 
         [Fact]
         public async Task CreateEventDefinitionAsync_WhenValidEvent_ShouldCreateEvent()
@@ -26,6 +41,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 
             // Act
             var result = await CustomEventApi.CreateEventDefinitionAsync(eventDefinition);
+            CustomEventsToCleanup.Add(result.Name);
 
             // Assert
             using (new AssertionScope())
@@ -44,24 +60,14 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task DeleteEventDefinitionAsync_WhenValidEvent_ShouldDeleteEvent()
         {
             // Arrange
-            var eventDefinition = new EventDefinition
-            {
-                Name = "test_event_" + Guid.NewGuid().ToString("N"),
-                Label = "Test Event",
-                Labels = new SchemasLabelsModel { Singular = "Test Event" },
-                Description = "Test event description",
-                PrimaryObjectId = "0-1",
-                TrackingType = "MANUAL"
-            };
-
-            var createdEvent = await CustomEventApi.CreateEventDefinitionAsync(eventDefinition);
-            createdEvent.Should().NotBeNull();
+            var eventDefinition = await CreateUniqueEventDefinitionAsync();
 
             // Act
-            await CustomEventApi.DeleteEventDefinitionAsync(createdEvent.Name);
+            await CustomEventApi.DeleteEventDefinitionAsync(eventDefinition.Name);
+            CustomEventsToCleanup.Remove(eventDefinition.Name);
 
             // Assert
-            var deletedEvent = await CustomEventApi.GetByNameAsync<EventDefinition>(createdEvent.Name);
+            var deletedEvent = await CustomEventApi.GetByNameAsync<EventDefinition>(eventDefinition.Name);
             deletedEvent.Should().BeNull();
         }
 
@@ -78,15 +84,15 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 
         [Fact]
         public async Task SendEventTrackingDataForContact_WhenValidData_ShouldSucceedWithNoException()
-        {            
-            var eventDefinition = await GetTestEventDefinition();
+        {
+            var eventDefinition = await CreateUniqueEventDefinitionAsync();
             var contact = await RecreateTestContactAsync();
 
             var eventTracking = CreateTestEventTracking(contact.Email, eventDefinition.FullyQualifiedName);
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
 
-            await act.Should().NotThrowAsync();            
+            await act.Should().NotThrowAsync();
         }
 
         [Fact]
@@ -103,23 +109,25 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         [Fact]
         public async Task SendEventTrackingDataForContact_WhenInvalidEmail_ShouldNotThrowException()
         {
-            var eventDefinition = await GetTestEventDefinition();
+            var eventDefinition = await CreateUniqueEventDefinitionAsync();
 
             var eventTracking = CreateTestEventTracking("invalid_email", eventDefinition.FullyQualifiedName);
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
 
             await act.Should().NotThrowAsync();
-        }        
+        }
 
         [Fact]
         public async Task GetByNameAsync_WhenValidEventName_ShouldReturnEvent()
         {
-            var result = await CustomEventApi.GetByNameAsync<EventDefinition>(EventName);
+            var eventDefinition = await CreateUniqueEventDefinitionAsync();
+
+            var result = await CustomEventApi.GetByNameAsync<EventDefinition>(eventDefinition.Name);
 
             result.Should().BeEquivalentTo(new EventDefinition
             {
-                Name = EventName,
+                Name = eventDefinition.Name,
                 Labels = new SchemasLabelsModel() { Singular = "Test Event" }
             }, options =>
             options
@@ -137,7 +145,8 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task SendEventTrackingDataForCompany_WhenValidData_ShouldSucceedWithNoException()
         {
             var company = await RecreateTestCompanyAsync();
-            var eventDefinition = await GetTestEventDefinition("test_event2", "COMPANY");
+            var eventDefinition = await CreateUniqueEventDefinitionAsync("0-2"); // 0-2 is the ID for COMPANY
+
             var eventTracking = CreateTestEventTracking(company.Id.Value, eventDefinition.FullyQualifiedName);
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
@@ -149,7 +158,8 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task SendEventTrackingDataForCompany_WhenInvalidObjectId_ShouldNotThrowException()
         {
             long randomNonExistingCompanyId = 10000234;
-            var eventDefinition = await GetTestEventDefinition("test_event2", "COMPANY");
+            var eventDefinition = await CreateUniqueEventDefinitionAsync("0-2"); // 0-2 is the ID for COMPANY
+
             var eventTracking = CreateTestEventTracking(randomNonExistingCompanyId, eventDefinition.FullyQualifiedName);
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
@@ -158,7 +168,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         }
 
         private EventTracking CreateTestEventTracking(string email, string eventName)
-        {            
+        {
             return new EventTracking
             {
                 EventName = eventName,

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -9,7 +9,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 {
     public class HubSpotCustomEventApiAsyncIntegrationTests : HubSpotAsyncIntegrationTestBase
     {
-        private async Task<EventDefinition> CreateUniqueEventDefinitionAsync(string primaryObjectId = "0-1")
+        private async Task<EventDefinition> CreateUniqueEventDefinitionAsync(string primaryObjectId = HubSpotObjectTypes.CONTACT)
         {
             var eventDefinition = new EventDefinition
             {
@@ -36,7 +36,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
                 Label = "Test Event",
                 Labels = new SchemasLabelsModel { Singular = "Test Event" },
                 Description = "Test event description",
-                PrimaryObjectId = "0-1", // 0-1 is the ID for CONTACT
+                PrimaryObjectId = HubSpotObjectTypes.CONTACT,
                 TrackingType = "MANUAL"
             };
 
@@ -148,7 +148,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task SendEventTrackingDataForCompany_WhenValidData_ShouldSucceedWithNoException()
         {
             var company = await RecreateTestCompanyAsync();
-            var eventDefinition = await CreateUniqueEventDefinitionAsync("0-2"); // 0-2 is the ID for COMPANY
+            var eventDefinition = await CreateUniqueEventDefinitionAsync(HubSpotObjectTypes.COMPANY);
 
             var eventTracking = CreateTestEventTracking(company.Id.Value, eventDefinition.FullyQualifiedName);
 
@@ -161,7 +161,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         public async Task SendEventTrackingDataForCompany_WhenInvalidObjectId_ShouldNotThrowException()
         {
             long randomNonExistingCompanyId = 10000234;
-            var eventDefinition = await CreateUniqueEventDefinitionAsync("0-2"); // 0-2 is the ID for COMPANY
+            var eventDefinition = await CreateUniqueEventDefinitionAsync(HubSpotObjectTypes.COMPANY);
 
             var eventTracking = CreateTestEventTracking(randomNonExistingCompanyId, eventDefinition.FullyQualifiedName);
 

--- a/HubSpot.NET.IntegrationTests/Api/Deal/HubSpotDealApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Deal/HubSpotDealApiAsyncIntegrationTests.cs
@@ -107,7 +107,7 @@ public sealed class HubSpotDealApiAsyncIntegrationTests : HubSpotAsyncIntegratio
             allDeals.Should().NotBeNull();
             allDeals.Deals.Count.Should().Be(1);
             allDeals.Paging.Next.After.Should().NotBeEmpty();
-            allDeals.Paging.Next.Link.Should().Contain("https://api.hubapi.com/crm/v3/objects/deals?");
+            allDeals.Paging.Next.Link.Should().Contain($"https://api.hubapi.com/crm/v3/objects/{HubSpotObjectTypes.DEAL}?");
         }
 
         foreach (var deal in createdDeals)

--- a/HubSpot.NET.IntegrationTests/Api/Deal/HubSpotDealApiIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/Deal/HubSpotDealApiIntegrationTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Execution;
 using HubSpot.NET.Api;
 using HubSpot.NET.Api.Deal;
 using HubSpot.NET.Api.Deal.Dto;
+using HubSpot.NET.Core;
 
 namespace HubSpot.NET.IntegrationTests.Api.Deal;
 
@@ -104,7 +105,7 @@ public sealed class HubSpotDealApiIntegrationTests : HubSpotIntegrationTestBase
             allDeals.Should().NotBeNull();
             allDeals.Deals.Count.Should().Be(1);
             allDeals.Paging.Next.After.Should().NotBeEmpty();
-            allDeals.Paging.Next.Link.Should().Contain("https://api.hubapi.com/crm/v3/objects/deals?");
+            allDeals.Paging.Next.Link.Should().Contain($"https://api.hubapi.com/crm/v3/objects/{HubSpotObjectTypes.DEAL}?");
         }
 
         foreach (var deal in createdDeals)

--- a/HubSpot.NET.IntegrationTests/Api/LineItem/HubSpotLineItemApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/LineItem/HubSpotLineItemApiAsyncIntegrationTests.cs
@@ -170,6 +170,7 @@ public sealed class HubSpotLineItemApiAsyncIntegrationTests : HubSpotAsyncIntegr
         newLineItem.Properties.Price = 100;
 
         var createdLineItem = await LineItemApi.CreateAsync<LineItemCreateOrUpdateRequest, LineItemGetResponse>(newLineItem);
+        LineItemsToCleanup.Add(createdLineItem.Id.Value);
         return (newLineItem, createdLineItem);
     }
 }

--- a/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotAsyncIntegrationTestBase.cs
@@ -86,9 +86,9 @@ public abstract class HubSpotAsyncIntegrationTestBase : HubSpotIntegrationTestSe
     {
         try
         {
-            await HubSpotApi.Associations.AssociationToObjectAsync(HubSpotObjectIds.Company,
+            await HubSpotApi.Associations.AssociationToObjectAsync(HubSpotObjectTypes.COMPANY,
                 company.Id.Value.ToString(),
-                HubSpotObjectIds.Contact, contact.Id.Value.ToString());
+                HubSpotObjectTypes.CONTACT, contact.Id.Value.ToString());
         }
         catch (Exception ex)
         {

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestBase.cs
@@ -82,8 +82,8 @@ public abstract class HubSpotIntegrationTestBase : HubSpotIntegrationTestSetup
     {
         try
         {
-            HubSpotApi.Associations.AssociationToObject(HubSpotObjectIds.Company, company.Id.Value.ToString(),
-                HubSpotObjectIds.Contact, contact.Id.Value.ToString());
+            HubSpotApi.Associations.AssociationToObject(HubSpotObjectTypes.COMPANY, company.Id.Value.ToString(),
+                HubSpotObjectTypes.CONTACT, contact.Id.Value.ToString());
         }
         catch (Exception ex)
         {

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestSetup.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestSetup.cs
@@ -4,7 +4,7 @@ using HubSpot.NET.Api.Contact;
 using HubSpot.NET.Api.ContactList;
 using HubSpot.NET.Api.CustomObject;
 using HubSpot.NET.Api.Deal;
-using HubSpot.NET.Api.LineItem.HubSpot.NET.Api.LineItems;
+using HubSpot.NET.Api.LineItem;
 using HubSpot.NET.Api.Properties;
 using HubSpot.NET.Core;
 using Microsoft.Extensions.Configuration;

--- a/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestSetup.cs
+++ b/HubSpot.NET.IntegrationTests/HubSpotIntegrationTestSetup.cs
@@ -34,6 +34,7 @@ public abstract class HubSpotIntegrationTestSetup : IAsyncLifetime
     protected readonly IList<string> CompanyPropertiesToCleanup = new List<string>();
     protected readonly IList<long> DealsToCleanup = new List<long>();
     protected readonly IList<long> LineItemsToCleanup = new List<long>();
+    protected readonly IList<string> CustomEventsToCleanup = new List<string>();
 
     protected HubSpotIntegrationTestSetup()
     {
@@ -75,6 +76,7 @@ public abstract class HubSpotIntegrationTestSetup : IAsyncLifetime
         await CleanCompanyPropertiesAsync();
         await CleanDealsAsync();
         await CleanLineItemsAsync();
+        await CleanCustomEventsAsync();
     }
 
     private async Task CleanCompaniesAsync()
@@ -162,6 +164,21 @@ public abstract class HubSpotIntegrationTestSetup : IAsyncLifetime
         catch
         {
             // Ignore errors during cleanup
+        }
+    }
+
+    private async Task CleanCustomEventsAsync()
+    {
+        foreach (var eventName in CustomEventsToCleanup)
+        {
+            try
+            {
+                await CustomEventApi.DeleteEventDefinitionAsync(eventName);
+            }
+            catch
+            {
+                // Ignore errors during cleanup
+            }
         }
     }
 }

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -27,7 +27,6 @@ namespace HubSpot.NET.Api.Associations
             var associationPath =
                 $"/crm/v4/objects/{objectType}/{objectId}/associations/default/{toObjectType}/{toObjectId}";
             _client.Execute(associationPath, null, Method.Put, convertToPropertiesSchema: false);
-
         }
 
         /// <summary>
@@ -87,7 +86,7 @@ namespace HubSpot.NET.Api.Associations
         {
             var associationPath = $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";            
 
-            return _client.ExecuteListAsync<T>(associationPath, Method.Get, convertToPropertiesSchema: false); ;
+            return _client.ExecuteListAsync<T>(associationPath, Method.Get, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/Company/Dto/CompanySearchHubSpotModel.cs
+++ b/HubSpot.NET/Api/Company/Dto/CompanySearchHubSpotModel.cs
@@ -22,7 +22,7 @@ namespace HubSpot.NET.Api.Company.Dto
         [DataMember(Name = "results")]
         public IList<T> Results { get; set; } = new List<T>();
 
-        public string RouteBasePath => "/crm/v3/objects/companies";
+        public string RouteBasePath => $"/crm/v3/objects/{Core.HubSpotObjectTypes.COMPANY}";
 
         public bool IsNameValue => false;
 

--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -142,7 +142,7 @@ namespace HubSpot.NET.Api.Company
             if (opts == null)
                 opts = new SearchRequestOptions();
 
-            var path = "/crm/v3/objects/companies/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.COMPANY}/search";
 
             CompanySearchHubSpotModel<T> data =
                 _client.ExecuteList<CompanySearchHubSpotModel<T>>(path, opts, Method.Post,
@@ -296,7 +296,7 @@ namespace HubSpot.NET.Api.Company
             if (opts == null)
                 opts = new SearchRequestOptions();
 
-            var path = "/crm/v3/objects/companies/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.COMPANY}/search";
 
             return _client.ExecuteListAsync<CompanySearchHubSpotModel<T>>(path, opts, Method.Post,
                 convertToPropertiesSchema: true);

--- a/HubSpot.NET/Api/Contact/Dto/ContactSearchHubSpotModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactSearchHubSpotModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using HubSpot.NET.Core;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.Contact.Dto
@@ -16,7 +17,7 @@ namespace HubSpot.NET.Api.Contact.Dto
         [DataMember(Name = "results")]
         public IList<T> Results { get; set; } = new List<T>();
 
-        public string RouteBasePath => "/crm/v3/objects/contacts/search";
+        public string RouteBasePath => $"/crm/v3/objects/{HubSpotObjectTypes.CONTACT}/search";
 
         public bool IsNameValue => false;
 

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -219,7 +219,7 @@ namespace HubSpot.NET.Api.Contact
         {
             opts ??= new SearchRequestOptions();
 
-            const string path = "/crm/v3/objects/contacts/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.CONTACT}/search";
 
             var data = _client.ExecuteList<ContactSearchHubSpotModel<T>>(path, opts, Method.Post,
                 convertToPropertiesSchema: true);
@@ -428,7 +428,7 @@ namespace HubSpot.NET.Api.Contact
         {
             opts ??= new SearchRequestOptions();
 
-            const string path = "/crm/v3/objects/contacts/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.CONTACT}/search";
 
             return _client.ExecuteListAsync<ContactSearchHubSpotModel<T>>(path, opts, Method.Post,
                 convertToPropertiesSchema: true);

--- a/HubSpot.NET/Api/CustomEvent/Dto/EventDefinition.cs
+++ b/HubSpot.NET/Api/CustomEvent/Dto/EventDefinition.cs
@@ -7,8 +7,11 @@ namespace HubSpot.NET.Api.CustomEvent.Dto
     [DataContract]
     public class EventDefinition : IHubSpotModel
     {
+        [DataMember(Name = "label")]
+        public string Label { get; set; }
+
         [DataMember(Name = "labels")]
-        public SchemasLabelsModel Label { get; set; }
+        public SchemasLabelsModel Labels { get; set; }
         
         [DataMember(Name="name")]
         public string Name { get; set; }
@@ -16,11 +19,26 @@ namespace HubSpot.NET.Api.CustomEvent.Dto
         [DataMember(Name = "description")]
         public string Description { get; set; }
 
-        [DataMember(Name = "primaryObject")]
-        public string PrimaryObject { get; set; }
+        [DataMember(Name = "primaryObjectId")]
+        public string PrimaryObjectId { get; set; }
 
         [DataMember(Name = "fullyQualifiedName")]
         public string FullyQualifiedName { get; set; }
+
+        [DataMember(Name = "archived")]
+        public bool Archived { get; set; }
+
+        [DataMember(Name = "trackingType")]
+        public string TrackingType { get; set; }
+
+        [DataMember(Name = "id")]
+        public string Id { get; set; }
+
+        [DataMember(Name = "createdAt")]
+        public string CreatedAt { get; set; }
+
+        [DataMember(Name = "updatedAt")]
+        public string UpdatedAt { get; set; }
 
         public bool IsNameValue => true;
 

--- a/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
@@ -43,5 +43,11 @@ namespace HubSpot.NET.Api.CustomEvent
             var path = new T().RouteBasePath;
             return _client.ExecuteAsync<T>(path, eventDefinition, Method.Post, convertToPropertiesSchema: false);
         }
+
+        public Task DeleteEventDefinitionAsync(string eventName)
+        {
+            var path = $"{new EventDefinition().RouteBasePath}/{eventName}";
+            return _client.ExecuteAsync(path, null, Method.Delete, convertToPropertiesSchema: false);
+        }
     }
 }

--- a/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Api/CustomEvent/HubSpotCustomEventApi.cs
@@ -37,5 +37,11 @@ namespace HubSpot.NET.Api.CustomEvent
                 throw;
             }
         }
+
+        public Task<T> CreateEventDefinitionAsync<T>(T eventDefinition) where T : EventDefinition, new()
+        {
+            var path = new T().RouteBasePath;
+            return _client.ExecuteAsync<T>(path, eventDefinition, Method.Post, convertToPropertiesSchema: false);
+        }
     }
 }

--- a/HubSpot.NET/Api/Deal/Dto/DealListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Deal/Dto/DealListHubSpotModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using HubSpot.NET.Core;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.Deal.Dto
@@ -16,7 +17,7 @@ namespace HubSpot.NET.Api.Deal.Dto
         [DataMember(Name = "paging")]
         public PagingModel Paging { get; set; } = new PagingModel();
 
-        public string RouteBasePath => "/crm/v3/objects";
+        public string RouteBasePath => $"/crm/v3/objects/{HubSpotObjectTypes.DEAL}";
 
         public bool IsNameValue => false;
         public virtual void ToHubSpotDataEntity(ref dynamic dataEntity)

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -111,7 +111,7 @@ namespace HubSpot.NET.Api.Deal
             if (opts == null)
                 opts = new DealListRequestOptions();
 
-            var path = $"{new DealListHubSpotModel<T>().RouteBasePath}/deals"
+            var path = $"{new DealListHubSpotModel<T>().RouteBasePath}"
                 .SetQueryParam("limit", opts.Limit);
 
             if (opts.Offset.HasValue)
@@ -133,7 +133,7 @@ namespace HubSpot.NET.Api.Deal
             if (opts == null)
                 opts = new DealListRequestOptions();
 
-            var path = $"{new DealListHubSpotModel<T>().RouteBasePath}/deals"
+            var path = $"{new DealListHubSpotModel<T>().RouteBasePath}"
                 .SetQueryParam("limit", opts.Limit);
 
             if (opts.Offset.HasValue)

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -265,7 +265,7 @@ namespace HubSpot.NET.Api.Deal
             if (opts == null)
                 opts = new SearchRequestOptions();
 
-            var path = "/crm/v3/objects/deals/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.DEAL}/search";
 
             var data = _client.ExecuteList<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
 
@@ -277,7 +277,7 @@ namespace HubSpot.NET.Api.Deal
             if (opts == null)
                 opts = new SearchRequestOptions();
 
-            var path = "/crm/v3/objects/deals/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.DEAL}/search";
 
             return _client.ExecuteListAsync<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
         }

--- a/HubSpot.NET/Api/LineItem/DTO/LineItemGetResponse.cs
+++ b/HubSpot.NET/Api/LineItem/DTO/LineItemGetResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using HubSpot.NET.Core;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.LineItem.DTO
@@ -44,7 +45,7 @@ namespace HubSpot.NET.Api.LineItem.DTO
         [DataMember(Name = "properties")]
         public LineItemPropertiesHubSpotModel Properties { get; set; } = new LineItemPropertiesHubSpotModel();
 
-        public string RouteBasePath => "/crm/v3/objects/line_items";
+        public string RouteBasePath => $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}";
         public bool IsNameValue => true;
 
         public virtual void ToHubSpotDataEntity(ref dynamic dataEntity)

--- a/HubSpot.NET/Api/LineItem/DTO/LineItemListHubSpotModel.cs
+++ b/HubSpot.NET/Api/LineItem/DTO/LineItemListHubSpotModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using HubSpot.NET.Core;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.LineItem.DTO
@@ -17,7 +18,7 @@ namespace HubSpot.NET.Api.LineItem.DTO
         [DataMember(Name = "paging")]
         public PagingModel Paging { get; set; } = new PagingModel();
 
-        public string RouteBasePath => "/crm/v3/objects/line_items";
+        public string RouteBasePath => $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}";
 
         public bool IsNameValue => false;
 

--- a/HubSpot.NET/Api/LineItem/HubSpotLineItemApi.cs
+++ b/HubSpot.NET/Api/LineItem/HubSpotLineItemApi.cs
@@ -25,14 +25,14 @@ namespace HubSpot.NET.Api.LineItem
                 where TRequest : LineItemCreateOrUpdateRequest, new()
                 where TResponse : LineItemGetResponse, new()
             {
-                var path = "/crm/v3/objects/line_items";
+                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}";
 
                 return _client.ExecuteAsync<TResponse>(path, entity, Method.Post, convertToPropertiesSchema: false);
             }
 
             public Task DeleteAsync(long lineItemId)
             {
-                var path = $"/crm/v3/objects/line_items/{lineItemId}";
+                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{lineItemId}";
                 return _client.ExecuteAsync(path, method: Method.Delete, convertToPropertiesSchema: false);
             }
 
@@ -59,7 +59,7 @@ namespace HubSpot.NET.Api.LineItem
                         : "";
 
                 var path =
-                    $"/crm/v3/objects/line_items/{lineItemId}?properties={propertiesQueryParam}{associationsQueryParam}";
+                    $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{lineItemId}?properties={propertiesQueryParam}{associationsQueryParam}";
 
                 try
                 {
@@ -84,7 +84,7 @@ namespace HubSpot.NET.Api.LineItem
                 if (entity.Id < 1)
                     throw new ArgumentException("Line Item entity must have an id set!");
 
-                var path = $"/crm/v3/objects/line_items/{entity.Id}";
+                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{entity.Id}";
 
                 return _client.ExecuteAsync<TResponse>(path, entity, Method.Patch, convertToPropertiesSchema: false);
             }
@@ -95,7 +95,7 @@ namespace HubSpot.NET.Api.LineItem
                 if (opts == null)
                     opts = new LineItemListRequestOptions();
 
-                var path = $"/crm/v3/objects/line_items"
+                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}"
                     .SetQueryParam("limit", opts.Limit);
 
                 if (opts.Offset.HasValue)
@@ -115,7 +115,7 @@ namespace HubSpot.NET.Api.LineItem
                 if (opts == null)
                     opts = new SearchRequestOptions();
 
-                var path = "/crm/v3/objects/line_items/search";
+                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/search";
 
                 return _client.ExecuteListAsync<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: false);
             }

--- a/HubSpot.NET/Api/LineItem/HubSpotLineItemApi.cs
+++ b/HubSpot.NET/Api/LineItem/HubSpotLineItemApi.cs
@@ -10,115 +10,112 @@ using RestSharp;
 
 namespace HubSpot.NET.Api.LineItem
 {
-    namespace HubSpot.NET.Api.LineItems
+    public class HubSpotLineItemApi : IHubSpotLineItemApi
     {
-        public class HubSpotLineItemApi : IHubSpotLineItemApi
+        private readonly IHubSpotClient _client;
+
+        public HubSpotLineItemApi(IHubSpotClient client)
         {
-            private readonly IHubSpotClient _client;
+            _client = client;
+        }
 
-            public HubSpotLineItemApi(IHubSpotClient client)
+        public Task<TResponse> CreateAsync<TRequest, TResponse>(TRequest entity)
+            where TRequest : LineItemCreateOrUpdateRequest, new()
+            where TResponse : LineItemGetResponse, new()
+        {
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}";
+
+            return _client.ExecuteAsync<TResponse>(path, entity, Method.Post, convertToPropertiesSchema: false);
+        }
+
+        public Task DeleteAsync(long lineItemId)
+        {
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{lineItemId}";
+            return _client.ExecuteAsync(path, method: Method.Delete, convertToPropertiesSchema: false);
+        }
+
+        public async Task<T> GetByIdAsync<T>(long lineItemId, LineItemListRequestOptions requestOptions = null)
+            where T : LineItemGetResponse, new()
+        {
+            requestOptions ??= new LineItemListRequestOptions();
+
+            if (requestOptions.PropertiesToInclude == null || requestOptions.PropertiesToInclude.Count == 0)
             {
-                _client = client;
+                requestOptions.PropertiesToInclude = new List<string> { "name", "price" };
             }
 
-            public Task<TResponse> CreateAsync<TRequest, TResponse>(TRequest entity)
-                where TRequest : LineItemCreateOrUpdateRequest, new()
-                where TResponse : LineItemGetResponse, new()
+            if (requestOptions.Associations == null || requestOptions.Associations.Count == 0)
             {
-                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}";
-
-                return _client.ExecuteAsync<TResponse>(path, entity, Method.Post, convertToPropertiesSchema: false);
+                requestOptions.Associations = new List<string> { "deals" };
             }
 
-            public Task DeleteAsync(long lineItemId)
+            var propertiesQueryParam = string.Join(",", requestOptions.PropertiesToInclude);
+
+            var associationsQueryParam =
+                requestOptions.Associations != null && requestOptions.Associations.Count > 0
+                    ? $"&associations={string.Join(",", requestOptions.Associations)}"
+                    : "";
+
+            var path =
+                $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{lineItemId}?properties={propertiesQueryParam}{associationsQueryParam}";
+
+            try
             {
-                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{lineItemId}";
-                return _client.ExecuteAsync(path, method: Method.Delete, convertToPropertiesSchema: false);
+                return await _client.ExecuteAsync<T>(path, Method.Get, convertToPropertiesSchema: false);
             }
-
-            public async Task<T> GetByIdAsync<T>(long lineItemId, LineItemListRequestOptions requestOptions = null)
-                where T : LineItemGetResponse, new()
+            catch (HubSpotException hubSpotEx)
             {
-                requestOptions ??= new LineItemListRequestOptions();
-
-                if (requestOptions.PropertiesToInclude == null || requestOptions.PropertiesToInclude.Count == 0)
+                if (hubSpotEx.ReturnedError.StatusCode == HttpStatusCode.NotFound)
                 {
-                    requestOptions.PropertiesToInclude = new List<string> { "name", "price" };
+                    throw new HubSpotException($"Line item with ID {lineItemId} does not exist.",
+                        new HubSpotError(hubSpotEx.ReturnedError.StatusCode, hubSpotEx.ReturnedError.Description));
                 }
 
-                if (requestOptions.Associations == null || requestOptions.Associations.Count == 0)
-                {
-                    requestOptions.Associations = new List<string> { "deals" };
-                }
-
-                var propertiesQueryParam = string.Join(",", requestOptions.PropertiesToInclude);
-
-                var associationsQueryParam =
-                    requestOptions.Associations != null && requestOptions.Associations.Count > 0
-                        ? $"&associations={string.Join(",", requestOptions.Associations)}"
-                        : "";
-
-                var path =
-                    $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{lineItemId}?properties={propertiesQueryParam}{associationsQueryParam}";
-
-                try
-                {
-                    return await _client.ExecuteAsync<T>(path, Method.Get, convertToPropertiesSchema: false);
-                }
-                catch (HubSpotException hubSpotEx)
-                {
-                    if (hubSpotEx.ReturnedError.StatusCode == HttpStatusCode.NotFound)
-                    {
-                        throw new HubSpotException($"Line item with ID {lineItemId} does not exist.",
-                            new HubSpotError(hubSpotEx.ReturnedError.StatusCode, hubSpotEx.ReturnedError.Description));
-                    }
-
-                    throw;
-                }
+                throw;
             }
+        }
 
-            public Task<TResponse> UpdateAsync<TRequest, TResponse>(TRequest entity)
-                where TRequest : LineItemCreateOrUpdateRequest, new()
-                where TResponse : LineItemGetResponse, new()
-            {
-                if (entity.Id < 1)
-                    throw new ArgumentException("Line Item entity must have an id set!");
+        public Task<TResponse> UpdateAsync<TRequest, TResponse>(TRequest entity)
+            where TRequest : LineItemCreateOrUpdateRequest, new()
+            where TResponse : LineItemGetResponse, new()
+        {
+            if (entity.Id < 1)
+                throw new ArgumentException("Line Item entity must have an id set!");
 
-                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{entity.Id}";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/{entity.Id}";
 
-                return _client.ExecuteAsync<TResponse>(path, entity, Method.Patch, convertToPropertiesSchema: false);
-            }
+            return _client.ExecuteAsync<TResponse>(path, entity, Method.Patch, convertToPropertiesSchema: false);
+        }
 
-            public Task<LineItemListHubSpotModel<T>> ListAsync<T>(LineItemListRequestOptions opts = null)
-                where T : LineItemGetResponse, new()
-            {
-                if (opts == null)
-                    opts = new LineItemListRequestOptions();
+        public Task<LineItemListHubSpotModel<T>> ListAsync<T>(LineItemListRequestOptions opts = null)
+            where T : LineItemGetResponse, new()
+        {
+            if (opts == null)
+                opts = new LineItemListRequestOptions();
 
-                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}"
-                    .SetQueryParam("limit", opts.Limit);
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}"
+                .SetQueryParam("limit", opts.Limit);
 
-                if (opts.Offset.HasValue)
-                    path = path.SetQueryParam("after", opts.Offset);
+            if (opts.Offset.HasValue)
+                path = path.SetQueryParam("after", opts.Offset);
 
-                return _client.ExecuteListAsync<LineItemListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
-            }
+            return _client.ExecuteListAsync<LineItemListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
+        }
 
-            /// <summary>
-            /// Gets a list of line items based on a search criteria
-            /// </summary>
-            /// <typeparam name="T">Implementation of <see cref="LineItemGetResponse"/></typeparam>
-            /// <param name="opts">Options (limit, offset) and search criteria relating to request</param>
-            /// <returns>List of line items</returns>
-            public Task<SearchHubSpotModel<T>> SearchAsync<T>(SearchRequestOptions opts = null) where T : LineItemGetResponse, new()
-            {
-                if (opts == null)
-                    opts = new SearchRequestOptions();
+        /// <summary>
+        /// Gets a list of line items based on a search criteria
+        /// </summary>
+        /// <typeparam name="T">Implementation of <see cref="LineItemGetResponse"/></typeparam>
+        /// <param name="opts">Options (limit, offset) and search criteria relating to request</param>
+        /// <returns>List of line items</returns>
+        public Task<SearchHubSpotModel<T>> SearchAsync<T>(SearchRequestOptions opts = null) where T : LineItemGetResponse, new()
+        {
+            if (opts == null)
+                opts = new SearchRequestOptions();
 
-                var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/search";
+            var path = $"/crm/v3/objects/{HubSpotObjectTypes.LINE_ITEM}/search";
 
-                return _client.ExecuteListAsync<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: false);
-            }
+            return _client.ExecuteListAsync<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/Properties/Dto/CompanyPropertyHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/CompanyPropertyHubSpotModel.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+using HubSpot.NET.Core;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.Properties.Dto
@@ -42,6 +39,6 @@ namespace HubSpot.NET.Api.Properties.Dto
         {
         }
 
-        public string RouteBasePath => "/companies";
+        public string RouteBasePath => $"/{HubSpotObjectTypes.COMPANY}";
     }
 }

--- a/HubSpot.NET/Core/HubSpotApi.cs
+++ b/HubSpot.NET/Core/HubSpotApi.cs
@@ -16,13 +16,6 @@ using HubSpot.NET.Core.OAuth.Dto;
 
 namespace HubSpot.NET.Core
 {
-    public class HubSpotObjectIds
-    {
-        public static readonly string Contact = "0-1";
-        public static readonly string Company = "0-2";
-        public static readonly string Deal = "0-3";
-    }
-    
     /// <summary>
     /// Starting point for using HubSpot.NET
     /// </summary>
@@ -34,8 +27,8 @@ namespace HubSpot.NET.Core
         public IHubSpotEngagementApi Engagement { get; protected set; }
         public IHubSpotCosFileApi File { get; protected set; }
         public IHubSpotOwnerApi Owner { get; protected set; }
-		public IHubSpotTasksApi Tasks { get; protected set; }
-		public IHubSpotCompanyPropertiesApi CompanyProperties { get; protected set; }
+        public IHubSpotTasksApi Tasks { get; protected set; }
+        public IHubSpotCompanyPropertiesApi CompanyProperties { get; protected set; }
         public IHubSpotCustomObjectPropertiesApi CustomObjectProperties { get; protected set; }
         public IHubSpotContactListApi ContactLists { get; protected set; }
 
@@ -47,7 +40,7 @@ namespace HubSpot.NET.Core
         public IHubSpotNoteApi Note { get; protected set; }
 
         protected virtual void Initialise(IHubSpotClient client)
-		{
+        {
             Company = new HubSpotCompanyApi(client);
             Contact = new HubSpotContactApi(client);
             Deal = new HubSpotDealApi(client);
@@ -64,20 +57,15 @@ namespace HubSpot.NET.Core
             Note = new HubSpotNoteApi(client);
         }
 
-        
-
-
         public HubSpotApi(string apiKey)
         {
             IHubSpotClient client = new HubSpotBaseClient(apiKey);
-
             Initialise(client);
         }
 
         public HubSpotApi(HubSpotToken token)
         {
             IHubSpotClient client = new HubSpotBaseClient(token);
-
             Initialise(client);
         }
     }

--- a/HubSpot.NET/Core/HubSpotObjectTypes.cs
+++ b/HubSpot.NET/Core/HubSpotObjectTypes.cs
@@ -1,0 +1,33 @@
+namespace HubSpot.NET.Core
+{
+    /// <summary>
+    /// Contains constants for HubSpot object type identifiers
+    /// </summary>
+    public static class HubSpotObjectTypes
+    {
+        /// <summary>
+        /// Object type ID for contacts (0-1)
+        /// </summary>
+        public const string CONTACT = "0-1";
+
+        /// <summary>
+        /// Object type ID for companies (0-2)
+        /// </summary>
+        public const string COMPANY = "0-2";
+
+        /// <summary>
+        /// Object type ID for deals (0-3)
+        /// </summary>
+        public const string DEAL = "0-3";
+
+        /// <summary>
+        /// Object type ID for line items (0-4)
+        /// </summary>
+        public const string LINE_ITEM = "0-4";
+
+        /// <summary>
+        /// Object type ID for tickets (0-5)
+        /// </summary>
+        public const string TICKET = "0-5";
+    }
+} 

--- a/HubSpot.NET/Core/HubSpotObjectTypes.cs
+++ b/HubSpot.NET/Core/HubSpotObjectTypes.cs
@@ -1,33 +1,39 @@
 namespace HubSpot.NET.Core
 {
     /// <summary>
-    /// Contains constants for HubSpot object type identifiers
+    /// Source: https://developers.hubspot.com/docs/guides/api/crm/using-object-apis
     /// </summary>
     public static class HubSpotObjectTypes
     {
-        /// <summary>
-        /// Object type ID for contacts (0-1)
-        /// </summary>
         public const string CONTACT = "0-1";
-
-        /// <summary>
-        /// Object type ID for companies (0-2)
-        /// </summary>
         public const string COMPANY = "0-2";
-
-        /// <summary>
-        /// Object type ID for deals (0-3)
-        /// </summary>
         public const string DEAL = "0-3";
-
-        /// <summary>
-        /// Object type ID for line items (0-4)
-        /// </summary>
-        public const string LINE_ITEM = "0-4";
-
-        /// <summary>
-        /// Object type ID for tickets (0-5)
-        /// </summary>
         public const string TICKET = "0-5";
+        public const string QUOTE = "0-14";
+        public const string PRODUCT = "0-7";
+        public const string LINE_ITEM = "0-8";
+        public const string CALL = "0-48";
+        public const string EMAIL = "0-49";
+        public const string MEETING = "0-47";
+        public const string TASK = "0-27";
+        public const string NOTE = "0-46";
+
+        // Rare or domain-specific types
+        public const string APPOINTMENT = "0-421";
+        public const string COMMUNICATION = "0-18";
+        public const string COURSE = "0-410";
+        public const string LEAD = "0-136";
+        public const string LISTING = "0-420";
+        public const string MARKETING_EVENT = "0-54";
+        public const string ORDER = "0-123";
+        public const string POSTAL_MAIL = "0-116";
+        public const string SERVICE = "0-162";
+        public const string SUBSCRIPTION = "0-69";
+        public const string USER = "0-115";
+
+        /// <summary>
+        /// Use this for custom objects — replace XXX with your object-specific ID.
+        /// </summary>
+        public const string CUSTOM_OBJECT_PREFIX = "2-";
     }
 } 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
@@ -8,5 +8,7 @@ namespace HubSpot.NET.Core.Interfaces
         Task SendEventTrackingData(EventTracking eventTracking);        
 
         Task<T> GetByNameAsync<T>(string eventName) where T : EventDefinition, new();
+
+        Task<T> CreateEventDefinitionAsync<T>(T eventDefinition) where T : EventDefinition, new();
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomEventApi.cs
@@ -10,5 +10,7 @@ namespace HubSpot.NET.Core.Interfaces
         Task<T> GetByNameAsync<T>(string eventName) where T : EventDefinition, new();
 
         Task<T> CreateEventDefinitionAsync<T>(T eventDefinition) where T : EventDefinition, new();
+
+        Task DeleteEventDefinitionAsync(string eventName);
     }
 }


### PR DESCRIPTION
## Description

This pull request addresses the [HubSpot API breaking change](https://developers.hubspot.com/changelog/breaking-change-removed-support-for-referencing-custom-object-types-by-base-name) (effective June 4, 2025), which removes support for referencing custom object types by base name. To ensure compatibility, the SDK now uses object type IDs for v3 and v4 API URLs. Earlier API versions continue to use literals for backward compatibility.

### API Path Updates and Events API Clarification

#### Context
During this update, we identified two distinct types of API endpoints in our codebase:
1. **CRM API endpoints** (e.g., `/crm/v3/objects/0-8/search`)
2. **Events API endpoints** (e.g., `/events/v3/event-definitions/test_event_09d556f66af84f6d973026536e6662b4`)

#### Changes
- **CRM API Endpoints:**  
  Only CRM API endpoints have been updated to use object type IDs (such as `0-1`, `0-2`, etc.), following the [HubSpot CRM Objects API documentation](https://developers.hubspot.com/docs/guides/api/crm/objects/custom-objects#retrieve-existing-custom-objects).
- **Events API Endpoints:**  
  Events API endpoints remain unchanged, as they belong to a separate API with different scopes and functionality.

#### Events API vs Marketing Events

There are two distinct event types in HubSpot:

1. **Behavioral Events** (Events API)
   - Uses `/events/v3/event-definitions` endpoints
   - Requires `behavioral_events.event_definitions.read_write` scope
   - Used for tracking user behavior and custom events
   - Example: `test_event_09d556f66af84f6d973026536e6662b4`

2. **Marketing Events** (CRM API)
   - Uses `/crm/v3/objects/0-54` endpoints
   - Requires `crm.objects.marketing_events.write` scope
   - Used for tracking marketing campaigns and activities
   - Represented as `MARKETING_EVENT = "0-54"` in `HubSpotObjectTypes`

#### Testing
We verified that:
- `/events/v3/event-definitions` works with our current scopes.
- `/events/v3/0-54` returns 404 Not Found.
- `/crm/v3/objects/0-54` requires additional scopes we don't have.
---

### Examples of New Formats

#### Companies
**Before:**
```
POST /crm/v3/objects/companies
```
**After:**
```
POST /crm/v3/objects/0-2
```

#### Deals
**Before:**
```
GET /crm/v3/objects/deals/search
```
**After:**
```
GET /crm/v3/objects/0-3/search
```

#### Associations between objects
**Before:**
```
PUT /crm/v4/objects/Company/123/associations/default/Contact/456
```
**After:**
```
PUT /crm/v4/objects/0-2/123/associations/default/0-1/456
```

#### Line items
**Before:**
```
DELETE /crm/v3/objects/line_items/789
```
**After:**
```
DELETE /crm/v3/objects/0-4/789
```

---

**Key changes in this PR:**

- **Centralization of Object Type Constants:**  
  Introduced a static class `HubSpotObjectTypes` to centralize HubSpot object type identifiers. All API classes and related tests were updated to use these constants, replacing previous hardcoded strings and the deprecated `HubSpotObjectIds` class.

- **API Path Refactors:**  
  All major CRM API route paths now use constants from `HubSpotObjectTypes`, ensuring consistency and simplifying route generation. This affects company, deal, contact, and association APIs, among others.

- **Expanded Object Type Coverage:**  
  Added new constants for additional HubSpot object types, including tickets, quotes, products, and activities (calls, meetings, etc.), to support broader API surface coverage.

- **Custom Event Definitions:**  
  Added support for creating and deleting custom event definitions via `CreateEventDefinitionAsync` and `DeleteEventDefinitionAsync`. The data model was updated to accommodate new event fields such as `Archived`, `TrackingType`, and timestamps.

- **Integration and Unit Test Improvements:**  
    - Refactored tests to use dynamically created, unique values, eliminating dependencies on hardcoded or constant values in the HubSpot ecosystem.
    - Added cleanup methods (`CleanCustomEventsAsync`) to ensure test isolation and reliability.
    - Improved exception handling in tests to assert correct API error responses.
    - Integration tests confirmed correctness by generating 159 unique endpoint URLs (see attachment).

- **General Codebase Cleanup:**  
    - Simplified the structure of the `HubSpotLineItemApi` and other classes by removing unnecessary nesting and redundant code.
    - Improved formatting and readability throughout the codebase.

- **Versioned API Support:**  
    v3 and v4 CRM API URLs are updated to use the new object type ID constants as required. Earlier versions continue to use literals for backward compatibility.

**Tests are successful**
![image](https://github.com/user-attachments/assets/9b961ed3-f93b-44f4-9155-7cc93df8cd4d)

In addition, the updated code integration tests generated 159 unique URLs, validating the correctness and coverage of the new and refactored endpoints (see the attached file for details).

[All_HubSpot_API_Requests.csv](https://github.com/user-attachments/files/20402833/All_HubSpot_API_Requests.csv)
