### PR TITLE
[PD-12307] Fix failing tests in HubSpotCustomEventApiAsyncIntegrationTests

### DIFF
--- a/HubSpot.NET.Examples/HubSpot.NET.Examples.csproj
+++ b/HubSpot.NET.Examples/HubSpot.NET.Examples.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HubSpot.NET\HubSpot.NET.csproj" />

--- a/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
+++ b/HubSpot.NET.IntegrationTests/Api/CustomEvent/HubSpotCustomEventApiAsyncIntegrationTests.cs
@@ -82,7 +82,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
             // Act & Assert
             Func<Task> act = async () => await CustomEventApi.DeleteEventDefinitionAsync(nonExistentEventName);
             await act.Should().ThrowAsync<HubSpotException>()
-                .Where(e => e.ReturnedError.StatusCode == HttpStatusCode.BadRequest);
+                .Where(e => e.ReturnedError.StatusCode == HttpStatusCode.NotFound);
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
         }
 
         [Fact]
-        public async Task SendEventTrackingDataForContact_WhenInvalidEmail_ShouldNotThrowException()
+        public async Task SendEventTrackingDataForContact_WhenInvalidEmail_ShouldThrowException()
         {
             var eventDefinition = await CreateUniqueEventDefinitionAsync();
 
@@ -118,7 +118,7 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 
             Func<Task> act = async () => await CustomEventApi.SendEventTrackingData(eventTracking);
 
-            await act.Should().NotThrowAsync();
+            await act.Should().ThrowAsync<HubSpotException>();
         }
 
         [Fact]
@@ -128,10 +128,15 @@ namespace HubSpot.NET.IntegrationTests.Api.CustomEvent
 
             var result = await CustomEventApi.GetByNameAsync<EventDefinition>(eventDefinition.Name);
 
+            var label = "Test Event";
             result.Should().BeEquivalentTo(new EventDefinition
             {
                 Name = eventDefinition.Name,
-                Labels = new SchemasLabelsModel() { Singular = "Test Event" }
+                Labels = new SchemasLabelsModel
+                {
+                    Singular = label,
+                    Plural = label
+                }
             }, options =>
             options
                 .Excluding(e => e.Description)

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.13</Version>
+    <Version>1.0.14</Version>
     <Authors>HubSpot.NET;Zanda Health</Authors>
     <Company>Zanda Health</Company>
     <Description>.NET client library targeting the HubSpot APIs.</Description>
@@ -20,7 +20,7 @@
       - Enhanced error handling and API response validation.
     </PackageReleaseNotes>
     <PackageId>PowerDiary.HubSpot.NET</PackageId>
-    <PackageVersion>1.0.13</PackageVersion>
+    <PackageVersion>1.0.14</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>8</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>

--- a/HubSpot.NET/HubSpot.NET.nuspec
+++ b/HubSpot.NET/HubSpot.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>PowerDiary.HubSpot.NET</id>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <releaseNotes>
       Added:
       - Updated API endpoints to use object type IDs for v3 and v4 CRM APIs to comply with HubSpot's breaking changes (effective June 4, 2025).


### PR DESCRIPTION
## Description
- Bump RestSharp version to 110.2.0 in project file.
- Adjust test to expect NotFound (404) for missing event deletion.
- Change invalid email event tracking test to expect exception.
- Update event label assertions to check both Singular and Plural.
- Upped version of project and Nuget

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have added tests to prove that what I have fixed or added does indeed work