### PR TITLE
[PD-17199] Add association label management support

### DIFF
--- a/HubSpot.NET/Api/Associations/Dto/AssociationLabelListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Associations/Dto/AssociationLabelListHubSpotModel.cs
@@ -1,0 +1,34 @@
+using HubSpot.NET.Core.Interfaces;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace HubSpot.NET.Api.Associations.Dto
+{
+    [DataContract]
+    public class AssociationLabelListHubSpotModel : IHubSpotModel
+    {
+        [JsonProperty(PropertyName = "results")]
+        public List<AssociationLabel> Results { get; set; } = new List<AssociationLabel>();
+
+        public class AssociationLabel
+        {
+            [JsonProperty(PropertyName = "category")]
+            public string Category { get; set; }
+
+            [JsonProperty(PropertyName = "typeId")]
+            public int TypeId { get; set; }
+
+            [JsonProperty(PropertyName = "label")]
+            public string Label { get; set; }
+        }
+
+        public bool IsNameValue => false;
+
+        public void ToHubSpotDataEntity(ref dynamic dataEntity) { }
+
+        public void FromHubSpotDataEntity(dynamic hubspotData) { }
+
+        public string RouteBasePath => "/crm/v4/associations/";
+    }
+}

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -84,9 +84,29 @@ namespace HubSpot.NET.Api.Associations
         /// <returns></returns>
         public Task<T> GetAssociationsAsync<T>(string objectType, string objectId, string toObjectType) where T : AssociationListHubSpotModel, new()
         {
-            var associationPath = $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";            
+            var associationPath = $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";
 
             return _client.ExecuteListAsync<T>(associationPath, Method.Get, convertToPropertiesSchema: false);
+        }
+
+        public Task RemoveAssociationLabelAsync(string objectType, string objectId, string toObjectType,
+            string toObjectId, string associationCategory, int associationTypeId)
+        {
+            var associationPath =
+                $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}/{toObjectId}";
+            var label = new
+            {
+                associationCategory,
+                associationTypeId
+            };
+            var body = new[] { label };
+            return _client.ExecuteAsync(associationPath, body, Method.Delete, convertToPropertiesSchema: false);
+        }
+
+        public Task<AssociationLabelListHubSpotModel> GetAssociationLabelsAsync(string fromObjectType, string toObjectType)
+        {
+            var path = $"/crm/v4/associations/{fromObjectType}/{toObjectType}/labels";
+            return _client.ExecuteListAsync<AssociationLabelListHubSpotModel>(path, Method.Get, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Core.Interfaces;
@@ -101,6 +103,19 @@ namespace HubSpot.NET.Api.Associations
             };
             var body = new[] { label };
             return _client.ExecuteAsync(associationPath, body, Method.Delete, convertToPropertiesSchema: false);
+        }
+
+        public Task SetAssociationLabelsAsync(string objectType, string objectId, string toObjectType,
+            string toObjectId, List<AssociationLabelListHubSpotModel.AssociationLabel> labels)
+        {
+            var associationPath =
+                $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}/{toObjectId}";
+            var body = labels.Select(l => new
+            {
+                associationCategory = l.Category,
+                associationTypeId = l.TypeId
+            }).ToArray();
+            return _client.ExecuteAsync(associationPath, body, Method.Put, convertToPropertiesSchema: false);
         }
 
         public Task<AssociationLabelListHubSpotModel> GetAssociationLabelsAsync(string fromObjectType, string toObjectType)

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -91,20 +91,6 @@ namespace HubSpot.NET.Api.Associations
             return _client.ExecuteListAsync<T>(associationPath, Method.Get, convertToPropertiesSchema: false);
         }
 
-        public Task RemoveAssociationLabelAsync(string objectType, string objectId, string toObjectType,
-            string toObjectId, string associationCategory, int associationTypeId)
-        {
-            var associationPath =
-                $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}/{toObjectId}";
-            var label = new
-            {
-                associationCategory,
-                associationTypeId
-            };
-            var body = new[] { label };
-            return _client.ExecuteAsync(associationPath, body, Method.Delete, convertToPropertiesSchema: false);
-        }
-
         public Task SetAssociationLabelsAsync(string objectType, string objectId, string toObjectType,
             string toObjectId, List<AssociationLabelListHubSpotModel.AssociationLabel> labels)
         {

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -16,5 +16,10 @@ namespace HubSpot.NET.Core.Interfaces
             string associationCategory, int associationTypeId);
 
         Task<T> GetAssociationsAsync<T>(string objectType, string objectId, string toObjectType) where T : AssociationListHubSpotModel, new();
+
+        Task RemoveAssociationLabelAsync(string objectType, string objectId, string toObjectType,
+            string toObjectId, string associationCategory, int associationTypeId);
+
+        Task<AssociationLabelListHubSpotModel> GetAssociationLabelsAsync(string fromObjectType, string toObjectType);
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -18,9 +18,6 @@ namespace HubSpot.NET.Core.Interfaces
 
         Task<T> GetAssociationsAsync<T>(string objectType, string objectId, string toObjectType) where T : AssociationListHubSpotModel, new();
 
-        Task RemoveAssociationLabelAsync(string objectType, string objectId, string toObjectType,
-            string toObjectId, string associationCategory, int associationTypeId);
-
         Task SetAssociationLabelsAsync(string objectType, string objectId, string toObjectType,
             string toObjectId, List<AssociationLabelListHubSpotModel.AssociationLabel> labels);
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using HubSpot.NET.Api.Associations.Dto;
 using System.Threading.Tasks;
 
@@ -19,6 +20,9 @@ namespace HubSpot.NET.Core.Interfaces
 
         Task RemoveAssociationLabelAsync(string objectType, string objectId, string toObjectType,
             string toObjectId, string associationCategory, int associationTypeId);
+
+        Task SetAssociationLabelsAsync(string objectType, string objectId, string toObjectType,
+            string toObjectId, List<AssociationLabelListHubSpotModel.AssociationLabel> labels);
 
         Task<AssociationLabelListHubSpotModel> GetAssociationLabelsAsync(string fromObjectType, string toObjectType);
     }

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
     <Authors>HubSpot.NET;Zanda Health</Authors>
     <Company>Zanda Health</Company>
     <Description>.NET client library targeting the HubSpot APIs.</Description>
@@ -12,15 +12,10 @@
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm custom objects</PackageTags>
     <PackageReleaseNotes>
       Added:
-      - Updated API endpoints to use object type IDs for v3 and v4 CRM APIs to comply with HubSpot's breaking changes (effective June 4, 2025).
-      - Centralized object type constants in HubSpotObjectTypes class.
-      - Added support for custom event definitions with CreateEventDefinitionAsync and DeleteEventDefinitionAsync.
-      - Added new constants for additional HubSpot object types (tickets, quotes, products, activities).
-      - Improved test reliability with dynamic test data and cleanup methods.
-      - Enhanced error handling and API response validation.
+      - RemoveAssociationLabelAsync method to remove specific association labels without removing the association itself.
     </PackageReleaseNotes>
     <PackageId>PowerDiary.HubSpot.NET</PackageId>
-    <PackageVersion>1.0.14</PackageVersion>
+    <PackageVersion>1.0.15</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>8</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -12,7 +12,9 @@
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm custom objects</PackageTags>
     <PackageReleaseNotes>
       Added:
-      - RemoveAssociationLabelAsync method to remove specific association labels without removing the association itself.
+      - SetAssociationLabelsAsync method to set multiple association labels in a single PUT call.
+      - GetAssociationLabelsAsync method to retrieve label definitions for an association type.
+      - AssociationLabelListHubSpotModel DTO for label definition responses.
     </PackageReleaseNotes>
     <PackageId>PowerDiary.HubSpot.NET</PackageId>
     <PackageVersion>1.0.15</PackageVersion>


### PR DESCRIPTION
## Description

Add support for managing association labels in HubSpot v4 API. This enables callers to:
- Set multiple association labels on a record pair in a single PUT call
- Retrieve label definitions for an association type (e.g. contact↔company)

### Changes:
- `SetAssociationLabelsAsync` — PUT endpoint to set multiple labels on an association in a single call (prevents label overwriting that occurs with per-label calls)
- `GetAssociationLabelsAsync` — GET endpoint to retrieve all label definitions for an association type
- `AssociationLabelListHubSpotModel` — new DTO for label definition responses
- Version bumped to 1.0.15

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [x] I have added documentation as necessary
